### PR TITLE
BC-59 Report files as 1 KB for near empty files.

### DIFF
--- a/PanoramicData.Blazor.Demo/Data/TestFileSystemDataProvider.cs
+++ b/PanoramicData.Blazor.Demo/Data/TestFileSystemDataProvider.cs
@@ -36,10 +36,11 @@ public class TestFileSystemDataProvider : IDataProviderService<FileExplorerItem>
 				new DirectoryEntry("stats.txt", FileExplorerItemType.File, 60766)
 			),
 			new DirectoryEntry("Temp",
-				new DirectoryEntry("p21wsa.tmp", FileExplorerItemType.File, 4096) { IsHidden = true },
-				new DirectoryEntry("a53fde.tmp", FileExplorerItemType.File, 1024) { IsHidden = true },
-				new DirectoryEntry("b76jba.tmp", FileExplorerItemType.File, 2048) { IsHidden = true },
-				new DirectoryEntry("z671hy.tmp", FileExplorerItemType.File, 0) { IsHidden = true }
+				new DirectoryEntry("1gigabyte.tmp", FileExplorerItemType.File, 1096000000) { IsHidden = true },
+				new DirectoryEntry("1kilobyte.tmp", FileExplorerItemType.File, 1024) { IsHidden = true },
+				new DirectoryEntry("2kilobytes.tmp", FileExplorerItemType.File, 2048) { IsHidden = true },
+				new DirectoryEntry("4bytes.tmp", FileExplorerItemType.File, 4) { IsHidden = true },
+				new DirectoryEntry("empty.tmp", FileExplorerItemType.File, 0) { IsHidden = true }
 			),
 			new DirectoryEntry("Cache",
 				new DirectoryEntry("document.docx", FileExplorerItemType.File, 4096),

--- a/PanoramicData.Blazor/PDFileExplorer.razor
+++ b/PanoramicData.Blazor/PDFileExplorer.razor
@@ -305,7 +305,7 @@
 								  Field="x => x.FileSize"
 								  Editable="false">
 							<Template>
-								<span class="@(GetCssClass(context))"
+								<span class="@(GetCssClass(context)) text-nowrap"
 									  title="@(context.FileSize.ToString("0,0")) bytes">
 									@(context.EntryType == FileExplorerItemType.Directory ? null : (context.FileSize > 0 && context.FileSize < 1000) ? 1000.Bytes().Humanize(SizeFormat) : context.FileSize.Bytes().Humanize(SizeFormat))
 								</span>

--- a/PanoramicData.Blazor/PDFileExplorer.razor
+++ b/PanoramicData.Blazor/PDFileExplorer.razor
@@ -307,7 +307,7 @@
 							<Template>
 								<span class="@(GetCssClass(context))"
 									  title="@(context.FileSize.ToString("0,0")) bytes">
-									@(context.EntryType == FileExplorerItemType.Directory ? null : context.FileSize.Bytes().Humanize(SizeFormat))
+									@(context.EntryType == FileExplorerItemType.Directory ? null : (context.FileSize > 0 && context.FileSize < 1000) ? 1000.Bytes().Humanize(SizeFormat) : context.FileSize.Bytes().Humanize(SizeFormat))
 								</span>
 							</Template>
 						</PDColumn>

--- a/PanoramicData.Blazor/PreviewProviders/FileExplorerPreviewProvider.cs
+++ b/PanoramicData.Blazor/PreviewProviders/FileExplorerPreviewProvider.cs
@@ -60,7 +60,7 @@ public class FileExplorerPreviewProvider : DefaultPreviewProvider
 			{
 				details.Add($"<span class=\"h1\">{Path.GetFileNameWithoutExtension(item.Name)}</span>");
 				details.Add($"<span class=\"h4\">{Path.GetExtension(item.Name)[1..].ToUpperInvariant()} File</span>");
-				details.Add($"<span title=\"{item.FileSize:N0} bytes\">{item.FileSize.Bytes().Humanize(FileExplorer.SizeFormat, CultureInfo.InvariantCulture)}</span>");
+				details.Add($"<span title=\"{item.FileSize:N0} bytes\">{item.FileSize.Bytes().Humanize( CultureInfo.InvariantCulture)}</span>");
 			}
 
 			details.Add($"<span title=\"{item.DateCreated}\" class=\"text-small text-muted\">Created: {dc}</span>");


### PR DESCRIPTION
#### PR Classification
Code cleanup and UI improvement.

#### PR Summary
This pull request updates the file system data provider by replacing temporary files and simplifies the file size display logic in the UI. Key changes include:
- `TestFileSystemDataProvider.cs`: Removed old temporary files and added new hidden temporary files with different sizes.
- `PDFileExplorer.razor`: Modified the template for displaying file sizes by removing unnecessary checks for sizes less than 1000 bytes.
- `FileExplorerPreviewProvider.cs`: Updated the humanization of file sizes by removing the `FileExplorer.SizeFormat` parameter from the `Humanize` method call.
