### PR TITLE
PDChat: allow disabling the message input (notifications-only mode) with an optional explanatory message

### DIFF
--- a/ComponentDocumentation.md
+++ b/ComponentDocumentation.md
@@ -225,6 +225,8 @@ This component has no public parameters.
 | OnMessageReceivedEvent | EventCallback<ChatMessage> | An event callback that is invoked when a message is received. |
 | OnAutoRestored | EventCallback | An event callback that is invoked when the chat window is automatically restored. |
 
+**Toast notifications:** PDChat can double as a toast surface. When a message arrives while the chat is closed (minimized, or fully hidden when `MinimizedButtonPosition` is `None`), it animates into view and, if auto-dismiss is enabled, animates out after a configurable time. Toasts stack (oldest at the top) and each runs its own independent dismiss timer. Defaults are set on `IChatService` via the `Toast*` members (`ToastEnabled`, `ToastEntryAnimation`, `ToastExitAnimation`, `ToastAnimationDurationMs`, `ToastAutoDismiss`, `ToastDisplayDurationSeconds`, `ToastShowTitle`, `ToastMinWidth`/`ToastMaxWidth`/`ToastMinHeight`/`ToastMaxHeight`, `ToastMaxVisible`, `ToastAnchor`) and can be overridden per message via `ChatMessage.ToastOptions`. The legacy `ShowLastMessage` / `ShowLastMessageDurationSeconds` members are obsolete and map onto `ToastEnabled` / `ToastDisplayDurationSeconds`.
+
 ---
 
 ## PDChatContainer

--- a/PanoramicData.Blazor.Demo/Pages/PDChatDocumentation.razor
+++ b/PanoramicData.Blazor.Demo/Pages/PDChatDocumentation.razor
@@ -13,4 +13,46 @@
 			</tbody>
 		</table>
 	</section>
+	<section id="toasts">
+		<h2 class="doc-section">Toast notifications</h2>
+		<p>
+			<code>PDChat</code> can double as a toast surface. When a message arrives while the chat is
+			<em>closed</em> &mdash; minimized to its button, or fully hidden when
+			<code>MinimizedButtonPosition</code> is <code>None</code> (a headless toast) &mdash; the message
+			animates into view. It stays for a configurable time and then, if auto-dismiss is enabled,
+			animates out again.
+		</p>
+		<p>
+			Multiple toasts <strong>stack</strong> (oldest at the top, newest at the bottom) and each runs
+			its own independent dismiss timer, so a longer-lived toast can outlast a later, shorter one.
+			While more than one toast is present, a dismissing toast leaves via a fixed de-stack animation;
+			the last remaining toast uses its own configured exit animation. Clicking a toast opens the
+			chat; hovering pauses its dismiss timer.
+		</p>
+		<p>
+			Defaults are configured on <code>IChatService</code> via the <code>Toast*</code> members and can
+			be overridden per message with <code>ChatMessage.ToastOptions</code> (any unset override falls
+			back to the service default).
+		</p>
+		<table class="table table-sm doc-props-table">
+			<thead><tr><th>IChatService member</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+			<tbody>
+				<tr><td><code>ToastEnabled</code></td><td><code>bool</code></td><td><code>true</code></td><td>Master switch (supersedes <code>ShowLastMessage</code>).</td></tr>
+				<tr><td><code>ToastEntryAnimation</code></td><td><code>PDChatToastAnimation</code></td><td><code>Grow</code></td><td>Animation used when a toast appears.</td></tr>
+				<tr><td><code>ToastExitAnimation</code></td><td><code>PDChatToastAnimation</code></td><td><code>Shrink</code></td><td>Animation used when a toast is dismissed.</td></tr>
+				<tr><td><code>ToastAnimationDurationMs</code></td><td><code>double</code></td><td><code>250</code></td><td>Entry / exit transition time in milliseconds.</td></tr>
+				<tr><td><code>ToastAutoDismiss</code></td><td><code>bool</code></td><td><code>true</code></td><td>Whether toasts auto-dismiss after the display duration.</td></tr>
+				<tr><td><code>ToastDisplayDurationSeconds</code></td><td><code>double</code></td><td><code>5</code></td><td>Dwell time before auto-dismiss (supersedes <code>ShowLastMessageDurationSeconds</code>).</td></tr>
+				<tr><td><code>ToastShowTitle</code></td><td><code>bool</code></td><td><code>true</code></td><td>Whether the message title is shown in the toast.</td></tr>
+				<tr><td><code>ToastMinWidth</code> / <code>ToastMaxWidth</code></td><td><code>string</code></td><td><code>200px</code> / <code>300px</code></td><td>Toast width constraints (any CSS length).</td></tr>
+				<tr><td><code>ToastMinHeight</code> / <code>ToastMaxHeight</code></td><td><code>string</code></td><td>(auto)</td><td>Toast height constraints (any CSS length).</td></tr>
+				<tr><td><code>ToastMaxVisible</code></td><td><code>int</code></td><td><code>5</code></td><td>Max toasts shown at once; the oldest is dismissed to make room.</td></tr>
+				<tr><td><code>ToastAnchor</code></td><td><code>PDChatButtonPosition</code></td><td><code>BottomRight</code></td><td>Corner the stack anchors to when the button is hidden (otherwise it follows the button).</td></tr>
+			</tbody>
+		</table>
+		<p class="text-muted small">
+			<code>ShowLastMessage</code> and <code>ShowLastMessageDurationSeconds</code> are obsolete and map onto
+			<code>ToastEnabled</code> / <code>ToastDisplayDurationSeconds</code> for backward compatibility.
+		</p>
+	</section>
 </div>

--- a/PanoramicData.Blazor.Demo/Pages/PDChatPage.razor
+++ b/PanoramicData.Blazor.Demo/Pages/PDChatPage.razor
@@ -133,11 +133,98 @@
 						<div class="form-text">Examples: HH:mm:ss, yyyy-MM-dd HH:mm, dd/MM/yyyy HH:mm:ss</div>
 					</div>
 
-					<div class="mb-3">
-						<label class="form-label small">Show Last Message Duration (seconds):</label>
-						<input type="number" @bind="ChatService.ShowLastMessageDurationSeconds" min="1" max="30" step="0.5" class="form-control form-control-sm" placeholder="5">
-						<div class="form-text">How long the message preview shows when the chat is minimized (1-30 seconds)</div>
+					<hr />
+					<h6 class="small text-uppercase text-muted mb-2"><i class="fas fa-bell me-1"></i>Toast Notifications</h6>
+					<div class="form-text mb-2">PDChat can double as a toast surface: messages arriving while the chat is closed animate in (and, when the chat button is hidden, appear headless). Minimize the chat, then use the buttons on the right.</div>
+
+					<div class="row">
+						<div class="col-6 mb-3">
+							<label class="form-label small">Entry Animation:</label>
+							<select @bind="ChatService.ToastEntryAnimation" class="form-select form-select-sm">
+								<option value="@PDChatToastAnimation.Grow">Grow</option>
+								<option value="@PDChatToastAnimation.Shrink">Shrink</option>
+								<option value="@PDChatToastAnimation.Fade">Fade</option>
+								<option value="@PDChatToastAnimation.Slide">Slide</option>
+								<option value="@PDChatToastAnimation.None">None</option>
+							</select>
+						</div>
+						<div class="col-6 mb-3">
+							<label class="form-label small">Exit Animation:</label>
+							<select @bind="ChatService.ToastExitAnimation" class="form-select form-select-sm">
+								<option value="@PDChatToastAnimation.Shrink">Shrink</option>
+								<option value="@PDChatToastAnimation.Grow">Grow</option>
+								<option value="@PDChatToastAnimation.Fade">Fade</option>
+								<option value="@PDChatToastAnimation.Slide">Slide</option>
+								<option value="@PDChatToastAnimation.None">None</option>
+							</select>
+						</div>
 					</div>
+
+					<div class="row">
+						<div class="col-6 mb-3">
+							<label class="form-label small">Animation Time (ms):</label>
+							<input type="number" @bind="ChatService.ToastAnimationDurationMs" min="0" max="2000" step="50" class="form-control form-control-sm">
+						</div>
+						<div class="col-6 mb-3">
+							<label class="form-label small">Display Duration (seconds):</label>
+							<input type="number" @bind="ChatService.ToastDisplayDurationSeconds" min="0.5" max="60" step="0.5" class="form-control form-control-sm">
+						</div>
+					</div>
+
+					<div class="row">
+						<div class="col-6 mb-3">
+							<label class="form-label small">Min / Max Width:</label>
+							<div class="input-group input-group-sm">
+								<input type="text" @bind="ChatService.ToastMinWidth" class="form-control" placeholder="200px">
+								<input type="text" @bind="ChatService.ToastMaxWidth" class="form-control" placeholder="300px">
+							</div>
+						</div>
+						<div class="col-6 mb-3">
+							<label class="form-label small">Min / Max Height:</label>
+							<div class="input-group input-group-sm">
+								<input type="text" @bind="ChatService.ToastMinHeight" class="form-control" placeholder="(auto)">
+								<input type="text" @bind="ChatService.ToastMaxHeight" class="form-control" placeholder="(auto)">
+							</div>
+						</div>
+					</div>
+
+					<div class="row">
+						<div class="col-6 mb-3">
+							<label class="form-label small">Max Visible Toasts:</label>
+							<input type="number" @bind="ChatService.ToastMaxVisible" min="1" max="10" step="1" class="form-control form-control-sm">
+						</div>
+						<div class="col-6 mb-3">
+							<label class="form-label small">Headless Anchor (button = None):</label>
+							<select @bind="ChatService.ToastAnchor" class="form-select form-select-sm">
+								<option value="@PDChatButtonPosition.BottomRight">Bottom Right</option>
+								<option value="@PDChatButtonPosition.BottomLeft">Bottom Left</option>
+								<option value="@PDChatButtonPosition.TopRight">Top Right</option>
+								<option value="@PDChatButtonPosition.TopLeft">Top Left</option>
+							</select>
+						</div>
+					</div>
+
+					<div class="row">
+						<div class="col-6">
+							<div class="form-check">
+								<input class="form-check-input" type="checkbox" @bind="ChatService.ToastEnabled" id="toastEnabledCheck">
+								<label class="form-check-label small" for="toastEnabledCheck">Enable Toasts</label>
+							</div>
+						</div>
+						<div class="col-6">
+							<div class="form-check">
+								<input class="form-check-input" type="checkbox" @bind="ChatService.ToastAutoDismiss" id="toastAutoDismissCheck">
+								<label class="form-check-label small" for="toastAutoDismissCheck">Auto-Dismiss</label>
+							</div>
+						</div>
+						<div class="col-6">
+							<div class="form-check">
+								<input class="form-check-input" type="checkbox" @bind="ChatService.ToastShowTitle" id="toastShowTitleCheck">
+								<label class="form-check-label small" for="toastShowTitleCheck">Show Title in Toast</label>
+							</div>
+						</div>
+					</div>
+					<hr />
 
 					<div class="row">
 						<div class="col-6">
@@ -160,6 +247,12 @@
 						</div>
 						<div class="col-6">
 							<div class="form-check">
+								<input class="form-check-input" type="checkbox" @bind="ChatService.IsInputPermitted" id="inputPermittedCheck">
+								<label class="form-check-label small" for="inputPermittedCheck">Enable Message Input</label>
+							</div>
+						</div>
+						<div class="col-6">
+							<div class="form-check">
 								<input class="form-check-input" type="checkbox" @bind="ChatService.AutoRestoreOnNewMessage" @bind:after="OnAutoRestoreChanged" id="autoRestoreCheck">
 								<label class="form-check-label small" for="autoRestoreCheck">Auto-Restore</label>
 							</div>
@@ -168,12 +261,6 @@
 							<div class="form-check">
 								<input class="form-check-input" type="checkbox" @bind="ChatService.UseFullWidthMessages" id="fullWidthCheck">
 								<label class="form-check-label small" for="fullWidthCheck">Full Width Messages</label>
-							</div>
-						</div>
-						<div class="col-6">
-							<div class="form-check">
-								<input class="form-check-input" type="checkbox" @bind="ChatService.ShowLastMessage" id="showLastMessageCheck">
-								<label class="form-check-label small" for="showLastMessageCheck">Show Last Message Preview</label>
 							</div>
 						</div>
 						<div class="col-6">
@@ -194,6 +281,12 @@
 								<label class="form-check-label small" for="showTimestampCheck">Show Timestamp</label>
 							</div>
 						</div>
+					</div>
+
+					<div class="mb-3 mt-2">
+						<label class="form-label small">Input Disabled Message (shown at the bottom when input is off):</label>
+						<input type="text" @bind="ChatService.InputDisabledMessage" @bind:event="oninput" class="form-control form-control-sm" placeholder="(blank = notifications-only, nothing shown)">
+						<div class="form-text">Uncheck "Enable Message Input" above to see this. Leave blank for pure toast-only mode (the input simply disappears with no message).</div>
 					</div>
 				</div>
 			</div>
@@ -250,7 +343,17 @@
 						</div>
 						<div class="col-12">
 							<button class="btn btn-outline-primary btn-sm w-100 mb-2" @onclick="TestMessagePreview">
-								<i class="fas fa-eye me-1"></i>Test Message Preview
+								<i class="fas fa-eye me-1"></i>Test Toast (single)
+							</button>
+						</div>
+						<div class="col-12">
+							<button class="btn btn-outline-info btn-sm w-100 mb-2" @onclick="TestToastStack">
+								<i class="fas fa-layer-group me-1"></i>Test Toast Stack (mixed durations)
+							</button>
+						</div>
+						<div class="col-12">
+							<button class="btn btn-outline-warning btn-sm w-100 mb-2" @onclick="TestToastOverride">
+								<i class="fas fa-sliders-h me-1"></i>Test Per-Message Override (slide, 12s)
 							</button>
 						</div>
 						<div class="col-12">

--- a/PanoramicData.Blazor.Demo/Pages/PDChatPage.razor.cs
+++ b/PanoramicData.Blazor.Demo/Pages/PDChatPage.razor.cs
@@ -201,16 +201,71 @@ public partial class PDChatPage : IDisposable
 		// Force chat to minimized state first
 		ChatService.PreferredDockMode = PDChatDockMode.Minimized;
 		await Task.Delay(100);
-		
+
 		var message = new ChatMessage
 		{
 			Id = Guid.NewGuid(),
-			Message = "👀 This message demonstrates the message preview feature! If enabled, you should see this message slide out from the chat button for a few seconds.",
+			Message = "👀 This message demonstrates the toast feature! With the chat closed, it animates in using the configured entry animation and auto-dismisses after the display duration.",
 			Sender = Bot,
 			Type = MessageType.Normal,
 			Timestamp = DateTime.UtcNow
 		};
 		ChatService.SendMessage(message);
+	}
+
+	// Sends three toasts in quick succession with different display durations to demonstrate the
+	// stacking behaviour: oldest at the top, each dismissing on its own independent timer.
+	private async Task TestToastStack()
+	{
+		ChatService.PreferredDockMode = PDChatDockMode.Minimized;
+		await Task.Delay(100);
+
+		var specs = new (string Text, MessageType Type, double Seconds)[]
+		{
+			("🥇 First toast — stays 12 seconds (oldest, at the top).", MessageType.Normal, 12),
+			("🥈 Second toast — stays 6 seconds.", MessageType.Warning, 6),
+			("🥉 Third toast — stays 2 seconds (dismisses first, de-stacking the others).", MessageType.Success, 2),
+		};
+
+		foreach (var spec in specs)
+		{
+			ChatService.SendMessage(new ChatMessage
+			{
+				Id = Guid.NewGuid(),
+				Message = spec.Text,
+				Sender = Bot,
+				Type = spec.Type,
+				Timestamp = DateTime.UtcNow,
+				ToastOptions = new ChatToastOptions { DisplayDurationSeconds = spec.Seconds }
+			});
+
+			await Task.Delay(300);
+		}
+	}
+
+	// Sends a single toast that overrides the service defaults on a per-message basis.
+	private async Task TestToastOverride()
+	{
+		ChatService.PreferredDockMode = PDChatDockMode.Minimized;
+		await Task.Delay(100);
+
+		ChatService.SendMessage(new ChatMessage
+		{
+			Id = Guid.NewGuid(),
+			Title = "Per-message override",
+			Message = "This toast overrides the defaults: it slides in and out, stays for 12 seconds, and uses a wider max-width — regardless of the service-level toast settings.",
+			Sender = Bot,
+			Type = MessageType.Normal,
+			Timestamp = DateTime.UtcNow,
+			ToastOptions = new ChatToastOptions
+			{
+				EntryAnimation = PDChatToastAnimation.Slide,
+				ExitAnimation = PDChatToastAnimation.Slide,
+				DisplayDurationSeconds = 12,
+				AnimationDurationMs = 350,
+				MaxWidth = "360px"
+			}
+		});
 	}
 
 	private void SendHtmlMessage()

--- a/PanoramicData.Blazor/Interfaces/IChatService.cs
+++ b/PanoramicData.Blazor/Interfaces/IChatService.cs
@@ -62,6 +62,29 @@ public interface IChatService
 	bool IsClearPermitted { get; set; }
 
 	/// <summary>
+	/// Gets or sets whether the user may type and send messages.
+	/// When false, the message input (text area and send button) is not rendered and
+	/// the chat acts as a notifications-only ("toast-only") surface. Defaults to true.
+	/// </summary>
+	bool IsInputPermitted
+	{
+		get => true;
+		set { }
+	}
+
+	/// <summary>
+	/// Gets or sets an optional message shown where the input would normally appear when
+	/// <see cref="IsInputPermitted"/> is false, e.g. to explain why sending is unavailable.
+	/// When null or empty (the default), nothing is rendered in place of the input, giving a
+	/// pure notifications-only surface. The message is rendered as plain text.
+	/// </summary>
+	string? InputDisabledMessage
+	{
+		get => null;
+		set { }
+	}
+
+	/// <summary>
 	/// Gets or sets whether the chat should auto-restore when new messages arrive.
 	/// </summary>
 	bool AutoRestoreOnNewMessage { get; set; }
@@ -99,13 +122,138 @@ public interface IChatService
 	/// <summary>
 	/// Gets or sets whether the last message should be shown as a preview when the chat is minimized and a new message arrives.
 	/// </summary>
+	[Obsolete("Superseded by the richer toast API. Use " + nameof(ToastEnabled) + " instead. This member maps onto " + nameof(ToastEnabled) + " for backward compatibility.")]
 	bool ShowLastMessage { get; set; }
 
 	/// <summary>
 	/// Gets or sets the duration in seconds for which the last message preview is shown before automatically hiding.
 	/// Default is 5 seconds.
 	/// </summary>
+	[Obsolete("Superseded by the richer toast API. Use " + nameof(ToastDisplayDurationSeconds) + " instead. This member maps onto " + nameof(ToastDisplayDurationSeconds) + " for backward compatibility.")]
 	double ShowLastMessageDurationSeconds { get; set; }
+
+	// ==========================================================================================
+	// Toast notification API
+	//
+	// PDChat can double as a toast surface: when a message arrives while the chat is "closed"
+	// (minimized to its button, or fully hidden when MinimizedButtonPosition is None) the chat
+	// animates the message into view, optionally auto-dismissing after a configurable time.
+	// Toasts stack (oldest at the top) and each runs its own independent dismiss timer.
+	//
+	// All members below carry default interface implementations so existing IChatService
+	// implementations continue to compile without change. ToastEnabled / ToastDisplayDurationSeconds
+	// default to the legacy ShowLastMessage / ShowLastMessageDurationSeconds members so that the
+	// previous behaviour is preserved for consumers that have not yet migrated.
+	// ==========================================================================================
+
+	/// <summary>
+	/// Gets or sets whether PDChat shows arriving messages as animated toasts while it is closed.
+	/// Supersedes <see cref="ShowLastMessage"/>; defaults to that member's value for backward compatibility.
+	/// </summary>
+	bool ToastEnabled
+	{
+#pragma warning disable CS0618 // Legacy member intentionally used as the default backing value.
+		get => ShowLastMessage;
+		set => ShowLastMessage = value;
+#pragma warning restore CS0618
+	}
+
+	/// <summary>Gets or sets the default animation used when a toast appears. Defaults to <see cref="PDChatToastAnimation.Grow"/>.</summary>
+	PDChatToastAnimation ToastEntryAnimation
+	{
+		get => PDChatToastAnimation.Grow;
+		set { }
+	}
+
+	/// <summary>Gets or sets the default animation used when a toast is dismissed. Defaults to <see cref="PDChatToastAnimation.Shrink"/>.</summary>
+	PDChatToastAnimation ToastExitAnimation
+	{
+		get => PDChatToastAnimation.Shrink;
+		set { }
+	}
+
+	/// <summary>Gets or sets the default duration, in milliseconds, of the toast entry / exit transitions. Defaults to 250ms.</summary>
+	double ToastAnimationDurationMs
+	{
+		get => 250d;
+		set { }
+	}
+
+	/// <summary>Gets or sets whether toasts auto-dismiss after <see cref="ToastDisplayDurationSeconds"/>. Defaults to true.</summary>
+	bool ToastAutoDismiss
+	{
+		get => true;
+		set { }
+	}
+
+	/// <summary>
+	/// Gets or sets how long, in seconds, a toast stays on screen before auto-dismissing.
+	/// Supersedes <see cref="ShowLastMessageDurationSeconds"/>; defaults to that member's value for backward compatibility.
+	/// </summary>
+	double ToastDisplayDurationSeconds
+	{
+#pragma warning disable CS0618 // Legacy member intentionally used as the default backing value.
+		get => ShowLastMessageDurationSeconds;
+		set => ShowLastMessageDurationSeconds = value;
+#pragma warning restore CS0618
+	}
+
+	/// <summary>Gets or sets whether the message title is shown in toasts by default. Defaults to true.</summary>
+	bool ToastShowTitle
+	{
+		get => true;
+		set { }
+	}
+
+	/// <summary>Gets or sets the default toast minimum width (any valid CSS length). Defaults to "200px".</summary>
+	string ToastMinWidth
+	{
+		get => "200px";
+		set { }
+	}
+
+	/// <summary>Gets or sets the default toast maximum width (any valid CSS length). Defaults to "300px".</summary>
+	string ToastMaxWidth
+	{
+		get => "300px";
+		set { }
+	}
+
+	/// <summary>Gets or sets the default toast minimum height (any valid CSS length). Empty means unconstrained.</summary>
+	string ToastMinHeight
+	{
+		get => string.Empty;
+		set { }
+	}
+
+	/// <summary>Gets or sets the default toast maximum height (any valid CSS length). Empty means unconstrained.</summary>
+	string ToastMaxHeight
+	{
+		get => string.Empty;
+		set { }
+	}
+
+	/// <summary>
+	/// Gets or sets the maximum number of toasts visible at once. When a new toast would exceed this,
+	/// the oldest is dismissed to make room. Defaults to 5.
+	/// </summary>
+	int ToastMaxVisible
+	{
+		get => 5;
+		set { }
+	}
+
+	/// <summary>
+	/// Gets or sets the corner the toast stack anchors to when the chat is fully hidden
+	/// (<see cref="MinimizedButtonPosition"/> is <see cref="PDChatButtonPosition.None"/>).
+	/// When the minimized button is visible, the stack follows the button's position instead.
+	/// Defaults to <see cref="PDChatButtonPosition.BottomRight"/>.
+	/// </summary>
+	PDChatButtonPosition ToastAnchor
+	{
+		get => PDChatButtonPosition.BottomRight;
+		set { }
+	}
 
 	/// <summary>
 	/// Gets the current list of chat messages.

--- a/PanoramicData.Blazor/Models/ChatMessage.cs
+++ b/PanoramicData.Blazor/Models/ChatMessage.cs
@@ -30,4 +30,12 @@ public class ChatMessage()
 
 	/// <summary>Gets or sets the UTC timestamp when the message was created. Defaults to <see cref="DateTimeOffset.UtcNow"/>.</summary>
 	public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
+
+	/// <summary>
+	/// Gets or sets optional per-message overrides for the toast shown when this message arrives while the
+	/// chat is closed. When <c>null</c>, the service-level <c>Toast*</c> defaults on
+	/// <see cref="Interfaces.IChatService"/> are used. Individual override properties that are left <c>null</c>
+	/// also fall back to the service defaults.
+	/// </summary>
+	public ChatToastOptions? ToastOptions { get; set; }
 }

--- a/PanoramicData.Blazor/Models/ChatToastOptions.cs
+++ b/PanoramicData.Blazor/Models/ChatToastOptions.cs
@@ -1,0 +1,40 @@
+namespace PanoramicData.Blazor.Models;
+
+/// <summary>
+/// Per-message overrides for the <see cref="PanoramicData.Blazor.PDChat"/> toast behaviour.
+/// Every property is nullable: a <c>null</c> value means "fall back to the service default"
+/// (the corresponding <c>Toast*</c> property on <see cref="Interfaces.IChatService"/>).
+/// Attach an instance to <see cref="ChatMessage.ToastOptions"/> to override the toast shown for that message.
+/// </summary>
+public class ChatToastOptions
+{
+	/// <summary>Overrides the animation used when the toast appears. Default entry is <see cref="PDChatToastAnimation.Grow"/>.</summary>
+	public PDChatToastAnimation? EntryAnimation { get; set; }
+
+	/// <summary>Overrides the animation used when the toast is dismissed. Default exit is <see cref="PDChatToastAnimation.Shrink"/>.</summary>
+	public PDChatToastAnimation? ExitAnimation { get; set; }
+
+	/// <summary>Overrides the duration, in milliseconds, of the entry / exit transitions.</summary>
+	public double? AnimationDurationMs { get; set; }
+
+	/// <summary>Overrides whether the toast automatically dismisses after <see cref="DisplayDurationSeconds"/>.</summary>
+	public bool? AutoDismiss { get; set; }
+
+	/// <summary>Overrides how long, in seconds, the toast stays on screen before auto-dismissing.</summary>
+	public double? DisplayDurationSeconds { get; set; }
+
+	/// <summary>Overrides whether the message title is shown in the toast.</summary>
+	public bool? ShowTitle { get; set; }
+
+	/// <summary>Overrides the toast minimum width (any valid CSS length, e.g. "200px").</summary>
+	public string? MinWidth { get; set; }
+
+	/// <summary>Overrides the toast maximum width (any valid CSS length, e.g. "300px").</summary>
+	public string? MaxWidth { get; set; }
+
+	/// <summary>Overrides the toast minimum height (any valid CSS length).</summary>
+	public string? MinHeight { get; set; }
+
+	/// <summary>Overrides the toast maximum height (any valid CSS length).</summary>
+	public string? MaxHeight { get; set; }
+}

--- a/PanoramicData.Blazor/Models/PDChatToastAnimation.cs
+++ b/PanoramicData.Blazor/Models/PDChatToastAnimation.cs
@@ -1,0 +1,24 @@
+namespace PanoramicData.Blazor.Models;
+
+/// <summary>
+/// Identifies the animation used when a <see cref="PanoramicData.Blazor.PDChat"/> toast enters or leaves the screen.
+/// The same catalogue is used for both the entry and exit phase; the meaning is direction-aware
+/// (for example, <see cref="Grow"/> grows on entry and the mirror shrink on exit).
+/// </summary>
+public enum PDChatToastAnimation
+{
+	/// <summary>No animation; the toast appears and disappears instantly.</summary>
+	None = 0,
+
+	/// <summary>The toast fades in / out via opacity only.</summary>
+	Fade = 1,
+
+	/// <summary>The toast grows from a small scale to full size (default entry animation).</summary>
+	Grow = 2,
+
+	/// <summary>The toast shrinks to a small scale (default exit animation).</summary>
+	Shrink = 3,
+
+	/// <summary>The toast slides in from / out towards the anchored edge.</summary>
+	Slide = 4
+}

--- a/PanoramicData.Blazor/PDChat.razor
+++ b/PanoramicData.Blazor/PDChat.razor
@@ -17,36 +17,54 @@
 							<span class="pdchat-priority-indicator">@GetPriorityIndicator()</span>
 						}
 					</button>
-					
-					@if (_showMessagePreview && _lastMessage != null && ChatService.ShowLastMessage)
+				</div>
+			}
+
+			@* Toast stack: shown whenever there are live toasts, whether or not the minimized button
+			   is visible. When the button is hidden (MinimizedButtonPosition.None) this is a headless toast. *@
+			@if (_toasts.Count > 0)
+			{
+				<div class="pdchat-toast-stack @GetToastAnchorClass()">
+					@foreach (var toast in _toasts)
 					{
-						<div class="pdchat-message-preview @(IsPositionOnRight() ? "slide-left" : "slide-right") @GetPreviewAnimationClass()">
+						<div @key="toast.Key"
+							 class="pdchat-message-preview pdchat-toast @GetToastClasses(toast)"
+							 style="@GetToastStyle(toast)"
+							 role="@(toast.Message.Type is MessageType.Error or MessageType.Critical ? "alert" : "status")"
+							 aria-live="@GetToastAriaLive(toast.Message.Type)"
+							 @onclick="OnToastClickedAsync"
+							 @onmouseenter="() => PauseToast(toast)"
+							 @onmouseleave="() => ResumeToast(toast)">
+							<button class="pdchat-toast-close"
+									@onclick="() => BeginDismiss(toast)"
+									@onclick:stopPropagation="true"
+									title="Dismiss">×</button>
 							<div class="pdchat-preview-header">
-								<span class="pdchat-preview-sender">@_lastMessage.Sender.Name</span>
-								<span class="pdchat-preview-timestamp">@_lastMessage.Timestamp.ToString("HH:mm")</span>
+								<span class="pdchat-preview-sender">@toast.Message.Sender.Name</span>
+								<span class="pdchat-preview-timestamp">@toast.Message.Timestamp.ToString("HH:mm")</span>
 							</div>
-							@if (!string.IsNullOrEmpty(_lastMessage.Title))
+							@if (toast.ShowTitle && !string.IsNullOrEmpty(toast.Message.Title))
 							{
 								<div class="pdchat-preview-title">
-									@if (_lastMessage.IsTitleHtml)
+									@if (toast.Message.IsTitleHtml)
 									{
-										@((MarkupString)_lastMessage.Title)
+										@((MarkupString)toast.Message.Title)
 									}
 									else
 									{
-										@_lastMessage.Title
+										@toast.Message.Title
 									}
 								</div>
 							}
 							<div class="pdchat-preview-content">
-                                @if (_lastMessage.IsMessageHtml)
-                                {
-                                    @((MarkupString)_lastMessage.Message)
-                                }
-                                else
-                                {
-                                    @_lastMessage.Message
-                                }
+								@if (toast.Message.IsMessageHtml)
+								{
+									@((MarkupString)toast.Message.Message)
+								}
+								else
+								{
+									@toast.Message.Message
+								}
 							</div>
 						</div>
 					}
@@ -103,6 +121,8 @@
 											CurrentInputChanged="@((string v) => _currentInput = v)"
 											IsLive="@ChatService.IsLive"
 											CanSend="@CanSend"
+											IsInputPermitted="@ChatService.IsInputPermitted"
+											InputDisabledMessage="@ChatService.InputDisabledMessage"
 											OnSendClicked="SendCurrentMessageAsync"
 											UserIconSelector="UserIconSelector"
 											UseFullWidthMessages="@ChatService.UseFullWidthMessages"
@@ -142,6 +162,8 @@
 											CurrentInputChanged="@((string v) => _currentInput = v)"
 											IsLive="@ChatService.IsLive"
 											CanSend="@CanSend"
+											IsInputPermitted="@ChatService.IsInputPermitted"
+											InputDisabledMessage="@ChatService.InputDisabledMessage"
 											OnSendClicked="SendCurrentMessageAsync"
 											UserIconSelector="UserIconSelector"
 											UseFullWidthMessages="@ChatService.UseFullWidthMessages"
@@ -162,6 +184,8 @@
 								CurrentInputChanged="@((string v) => _currentInput = v)"
 								IsLive="@ChatService.IsLive"
 								CanSend="@CanSend"
+								IsInputPermitted="@ChatService.IsInputPermitted"
+								InputDisabledMessage="@ChatService.InputDisabledMessage"
 								OnSendClicked="SendCurrentMessageAsync"
 								UserIconSelector="UserIconSelector"
 								UseFullWidthMessages="@ChatService.UseFullWidthMessages"

--- a/PanoramicData.Blazor/PDChat.razor.cs
+++ b/PanoramicData.Blazor/PDChat.razor.cs
@@ -109,9 +109,13 @@ public partial class PDChat : JSModuleComponentBase
 	private MessageType _highestPriorityUnreadMessage = MessageType.Normal;
 	private DateTimeOffset _lastReadTimestamp = DateTimeOffset.UtcNow;
 	private string _currentInput = "";
-	private bool _showMessagePreview;
-	private ChatMessage? _lastMessage;
-	private Timer? _messagePreviewTimer;
+
+	// Fixed duration, in milliseconds, of the "de-stack" animation used when a toast leaves a stack
+	// that still contains other toasts. Deliberately uniform and independent of any per-message
+	// animation configuration (see the toast stacking rules).
+	private const double DeStackDurationMs = 250d;
+
+	private readonly List<ToastItem> _toasts = [];
 
 	private readonly List<ChatMessage> _messages = [];
 	private PDTabSet? _tabSetRef;
@@ -236,15 +240,13 @@ public partial class PDChat : JSModuleComponentBase
 				UpdateHighestPriorityUnreadMessage();
 			}
 
-			// Show message preview if enabled and it's a new non-typing message
-			if (ChatService.ShowLastMessage && isNewMessage && message.Type != MessageType.Typing)
-			{
-				await ShowMessagePreviewAsync(message);
-			}
+			var isToastable = isNewMessage && message.Type != MessageType.Typing;
 
-			// Optionally auto-restore the chat when new messages arrive
-			if (ChatService.AutoRestoreOnNewMessage && isNewMessage && message.Type != MessageType.Typing)
+			// Auto-restore takes priority over toasts: if the chat is going to open anyway there is no
+			// point showing a toast for the same message.
+			if (ChatService.AutoRestoreOnNewMessage && isToastable)
 			{
+				ClearToasts();
 				await ChangeDockModeAsync(ChatService.RestoreMode);
 				_unreadMessages = false;
 				_highestPriorityUnreadMessage = MessageType.Normal;
@@ -254,6 +256,12 @@ public partial class PDChat : JSModuleComponentBase
 				{
 					await OnAutoRestored.InvokeAsync();
 				}
+			}
+			else if (ChatService.ToastEnabled && isToastable)
+			{
+				// Show the message as an animated toast. This works whether or not the minimized
+				// button is visible (MinimizedButtonPosition.None => headless toast).
+				await ShowToastAsync(message);
 			}
 		}
 
@@ -276,40 +284,157 @@ public partial class PDChat : JSModuleComponentBase
 		await InvokeAsync(StateHasChanged);
 	}
 
-	private async Task ShowMessagePreviewAsync(ChatMessage message)
+	/// <summary>
+	/// Adds a new toast for the supplied message, resolving per-message overrides against the
+	/// service-level defaults, enforcing the visible-toast cap, and starting its auto-dismiss timer.
+	/// </summary>
+	private async Task ShowToastAsync(ChatMessage message)
 	{
-		// Cancel any existing timer
-		if (_messagePreviewTimer is not null)
+		var o = message.ToastOptions;
+
+		var item = new ToastItem
 		{
-			await _messagePreviewTimer.DisposeAsync();
+			Message = message,
+			EntryAnimation = o?.EntryAnimation ?? ChatService.ToastEntryAnimation,
+			ExitAnimation = o?.ExitAnimation ?? ChatService.ToastExitAnimation,
+			AnimationDurationMs = o?.AnimationDurationMs ?? ChatService.ToastAnimationDurationMs,
+			AutoDismiss = o?.AutoDismiss ?? ChatService.ToastAutoDismiss,
+			DisplayDurationSeconds = o?.DisplayDurationSeconds ?? ChatService.ToastDisplayDurationSeconds,
+			ShowTitle = o?.ShowTitle ?? ChatService.ToastShowTitle,
+			MinWidth = o?.MinWidth ?? ChatService.ToastMinWidth,
+			MaxWidth = o?.MaxWidth ?? ChatService.ToastMaxWidth,
+			MinHeight = o?.MinHeight ?? ChatService.ToastMinHeight,
+			MaxHeight = o?.MaxHeight ?? ChatService.ToastMaxHeight,
+		};
+
+		// Enforce the visible-toast cap by dismissing the oldest still-present toasts.
+		var maxVisible = Math.Max(1, ChatService.ToastMaxVisible);
+		var overflow = _toasts.Count(t => !t.IsExiting) - (maxVisible - 1);
+		for (var i = 0; overflow > 0 && i < _toasts.Count; i++)
+		{
+			if (!_toasts[i].IsExiting)
+			{
+				BeginDismiss(_toasts[i]);
+				overflow--;
+			}
 		}
 
-		// Set the message to show
-		_lastMessage = message;
-		_showMessagePreview = true;
+		// Newest is added at the bottom of the stack (oldest remains at the top).
+		_toasts.Add(item);
 		await InvokeAsync(StateHasChanged);
 
-		// Set a timer to hide the message after the configured duration
-		_messagePreviewTimer = new Timer(_ =>
+		if (item.AutoDismiss && item.DisplayDurationSeconds > 0)
 		{
-			// Use InvokeAsync to ensure we're on the UI thread
-			_ = InvokeAsync(() =>
+			StartDismissTimer(item, item.DisplayDurationSeconds * 1000d);
+		}
+	}
+
+	// (Re)starts the auto-dismiss timer for a toast, tracking the start time so hover-pause can
+	// compute the remaining time accurately.
+	private void StartDismissTimer(ToastItem item, double remainingMs)
+	{
+		item.DismissTimer?.Dispose();
+		item.RemainingMs = remainingMs;
+		item.StartedTicks = Environment.TickCount64;
+		item.Paused = false;
+		item.DismissTimer = new Timer(
+			_ => _ = InvokeAsync(() => BeginDismiss(item)),
+			null,
+			TimeSpan.FromMilliseconds(remainingMs),
+			Timeout.InfiniteTimeSpan);
+	}
+
+	// Pauses a toast's auto-dismiss countdown (e.g. while the pointer hovers over it).
+	private static void PauseToast(ToastItem item)
+	{
+		if (item.IsExiting || item.Paused || item.DismissTimer is null)
+		{
+			return;
+		}
+
+		var elapsed = Environment.TickCount64 - item.StartedTicks;
+		item.RemainingMs = Math.Max(0, item.RemainingMs - elapsed);
+		item.DismissTimer.Dispose();
+		item.DismissTimer = null;
+		item.Paused = true;
+	}
+
+	// Resumes a paused toast's auto-dismiss countdown from where it left off.
+	private void ResumeToast(ToastItem item)
+	{
+		if (item.IsExiting || !item.Paused)
+		{
+			return;
+		}
+
+		if (item.RemainingMs <= 0)
+		{
+			BeginDismiss(item);
+			return;
+		}
+
+		StartDismissTimer(item, item.RemainingMs);
+	}
+
+	// Begins the exit of a toast. If other toasts remain in the stack it leaves via the fixed
+	// de-stack animation; if it is the last one it uses its own configured exit animation.
+	private void BeginDismiss(ToastItem item)
+	{
+		if (item.IsExiting)
+		{
+			return;
+		}
+
+		item.DismissTimer?.Dispose();
+		item.DismissTimer = null;
+
+		var othersRemain = _toasts.Any(t => t != item && !t.IsExiting);
+		item.IsExiting = true;
+		item.IsDeStacking = othersRemain;
+
+		var exitMs = othersRemain ? DeStackDurationMs : item.AnimationDurationMs;
+
+		item.RemovalTimer?.Dispose();
+		item.RemovalTimer = new Timer(
+			_ => _ = InvokeAsync(() =>
 			{
-				_showMessagePreview = false;
-				_lastMessage = null;
+				item.RemovalTimer?.Dispose();
+				item.RemovalTimer = null;
+				_toasts.Remove(item);
 				StateHasChanged();
-			});
-		}, null, TimeSpan.FromSeconds(ChatService.ShowLastMessageDurationSeconds), Timeout.InfiniteTimeSpan);
+			}),
+			null,
+			TimeSpan.FromMilliseconds(Math.Max(1, exitMs)),
+			Timeout.InfiniteTimeSpan);
+
+		_ = InvokeAsync(StateHasChanged);
+	}
+
+	// Disposes every toast timer and clears the stack immediately (no exit animation).
+	private void ClearToasts()
+	{
+		foreach (var t in _toasts)
+		{
+			t.DismissTimer?.Dispose();
+			t.RemovalTimer?.Dispose();
+		}
+
+		_toasts.Clear();
+	}
+
+	// Invoked when a toast is clicked: opens the chat and clears the stack.
+	private async Task OnToastClickedAsync()
+	{
+		ClearToasts();
+		await ToggleChatAsync();
 	}
 
 	private async Task ToggleChatAsync()
 	{
 		if (ChatService.DockMode == PDChatDockMode.Minimized)
 		{
-			// Hide message preview when opening chat
-			_showMessagePreview = false;
-			_lastMessage = null;
-			_messagePreviewTimer?.Dispose();
+			// Dismiss any toasts when opening chat
+			ClearToasts();
 
 			// Restore to last normal state
 			await ChangeDockModeAsync(ChatService.RestoreMode);
@@ -443,7 +568,7 @@ public partial class PDChat : JSModuleComponentBase
 		_messagesComponent?.ClearInput();
 	}
 
-	private bool CanSend => ChatService.IsLive && !string.IsNullOrWhiteSpace(_currentInput);
+	private bool CanSend => ChatService.IsInputPermitted && ChatService.IsLive && !string.IsNullOrWhiteSpace(_currentInput);
 
 	private void OnTabAdded()
 	{
@@ -631,40 +756,116 @@ public partial class PDChat : JSModuleComponentBase
 		ChatService.OnMuteStatusChanged -= OnServiceMuteStatusChanged;
 		ChatService.OnConfigurationChanged -= OnServiceConfigurationChanged;
 
-		// Clean up timer
-		if (_messagePreviewTimer is not null)
-		{
-			await _messagePreviewTimer.DisposeAsync();
-		}
+		// Clean up toast timers
+		ClearToasts();
 
 		await base.DisposeAsync();
 
 		GC.SuppressFinalize(this);
 	}
 
-	// Helper method to determine if position is on the right side
-	private bool IsPositionOnRight()
+	// Maps a message type to its toast colour-scheme class (shared with the legacy preview styles).
+	private static string GetToastTypeClass(MessageType type) => type switch
 	{
-		return ChatService.MinimizedButtonPosition is
-			PDChatButtonPosition.BottomRight or
-			PDChatButtonPosition.TopRight;
+		MessageType.Warning => "preview-warning",
+		MessageType.Error => "preview-error",
+		MessageType.Critical => "preview-critical",
+		MessageType.Success => "preview-success",
+		_ => "preview-normal"
+	};
+
+	// Builds the full class list for a toast card: colour scheme, anchor side, and the current
+	// entry / exit / de-stack animation state.
+	private static string GetToastClasses(ToastItem item)
+	{
+		var animationClass = item.IsDeStacking
+			? "toast-destack"
+			: item.IsExiting
+				? $"toast-exit-{GetAnimationName(item.ExitAnimation)}"
+				: $"toast-enter-{GetAnimationName(item.EntryAnimation)}";
+
+		return $"{GetToastTypeClass(item.Message.Type)} {animationClass}";
 	}
 
-	// Helper method to get preview animation class based on priority
-	private string GetPreviewAnimationClass()
+	// Inline style carrying the resolved dimensions and the per-toast animation duration.
+	private static string GetToastStyle(ToastItem item)
 	{
-		if (_lastMessage == null)
-		{
-			return string.Empty;
-		}
+		var durationMs = item.IsDeStacking ? DeStackDurationMs : item.AnimationDurationMs;
+		var sb = new System.Text.StringBuilder();
+		sb.Append("--pdchat-toast-anim-ms:").Append(durationMs.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append("ms;");
+		AppendStyle(sb, "min-width", item.MinWidth);
+		AppendStyle(sb, "max-width", item.MaxWidth);
+		AppendStyle(sb, "min-height", item.MinHeight);
+		AppendStyle(sb, "max-height", item.MaxHeight);
+		return sb.ToString();
+	}
 
-		return _lastMessage.Type switch
+	private static void AppendStyle(System.Text.StringBuilder sb, string name, string? value)
+	{
+		if (!string.IsNullOrWhiteSpace(value))
 		{
-			MessageType.Warning => "preview-warning",
-			MessageType.Error => "preview-error",
-			MessageType.Critical => "preview-critical",
-			MessageType.Success => "preview-success",
-			_ => "preview-normal"
+			sb.Append(name).Append(':').Append(value).Append(';');
+		}
+	}
+
+	private static string GetAnimationName(PDChatToastAnimation animation) => animation switch
+	{
+		PDChatToastAnimation.None => "none",
+		PDChatToastAnimation.Fade => "fade",
+		PDChatToastAnimation.Grow => "grow",
+		PDChatToastAnimation.Shrink => "shrink",
+		PDChatToastAnimation.Slide => "slide",
+		_ => "grow"
+	};
+
+	// Resolves the corner the toast stack anchors to: follow the minimized button when it is shown,
+	// otherwise fall back to the configured headless anchor.
+	private string GetToastAnchorClass()
+	{
+		var anchor = ChatService.MinimizedButtonPosition == PDChatButtonPosition.None
+			? ChatService.ToastAnchor
+			: ChatService.MinimizedButtonPosition;
+
+		return anchor switch
+		{
+			PDChatButtonPosition.TopLeft => "toast-anchor-top-left",
+			PDChatButtonPosition.TopRight => "toast-anchor-top-right",
+			PDChatButtonPosition.BottomLeft => "toast-anchor-bottom-left",
+			PDChatButtonPosition.BottomRight => "toast-anchor-bottom-right",
+			PDChatButtonPosition.None => "toast-anchor-bottom-right",
+			_ => "toast-anchor-bottom-right"
 		};
+	}
+
+	// aria-live politeness: escalate to assertive for the most severe message types.
+	private static string GetToastAriaLive(MessageType type)
+		=> type is MessageType.Error or MessageType.Critical ? "assertive" : "polite";
+
+	/// <summary>
+	/// Represents a single live toast instance in the stack, together with its resolved presentation
+	/// options and auto-dismiss timers.
+	/// </summary>
+	private sealed class ToastItem
+	{
+		public Guid Key { get; } = Guid.NewGuid();
+		public required ChatMessage Message { get; init; }
+		public PDChatToastAnimation EntryAnimation { get; init; }
+		public PDChatToastAnimation ExitAnimation { get; init; }
+		public double AnimationDurationMs { get; init; }
+		public bool AutoDismiss { get; init; }
+		public double DisplayDurationSeconds { get; init; }
+		public bool ShowTitle { get; init; }
+		public string? MinWidth { get; init; }
+		public string? MaxWidth { get; init; }
+		public string? MinHeight { get; init; }
+		public string? MaxHeight { get; init; }
+
+		public bool IsExiting { get; set; }
+		public bool IsDeStacking { get; set; }
+		public Timer? DismissTimer { get; set; }
+		public Timer? RemovalTimer { get; set; }
+		public bool Paused { get; set; }
+		public double RemainingMs { get; set; }
+		public long StartedTicks { get; set; }
 	}
 }

--- a/PanoramicData.Blazor/PDChat.razor.css
+++ b/PanoramicData.Blazor/PDChat.razor.css
@@ -822,3 +822,208 @@ body:has(.pdchat-container.dock-fullscreen) {
 		border-color: #5ba4fc;
 	}
 }
+/* ==============================================
+   Toast Stack (PDChat as a toast surface)
+   ============================================== */
+
+/* The stack is anchored to a viewport corner independently of the minimized button, so toasts
+   work even when the button is hidden (MinimizedButtonPosition.None => headless toasts).
+   The container itself is click-through; individual toasts re-enable pointer events. */
+.pdchat-toast-stack {
+	position: fixed;
+	z-index: 10002;
+	display: flex;
+	flex-direction: column; /* oldest first (top), newest last (bottom) */
+	gap: 8px;
+	max-width: 90vw;
+	pointer-events: none;
+}
+
+.pdchat-toast-stack.toast-anchor-bottom-right {
+	bottom: 80px; /* leave room for the minimized button when shown */
+	right: 20px;
+	align-items: flex-end;
+}
+
+.pdchat-toast-stack.toast-anchor-bottom-left {
+	bottom: 80px;
+	left: 20px;
+	align-items: flex-start;
+}
+
+.pdchat-toast-stack.toast-anchor-top-right {
+	top: 80px;
+	right: 20px;
+	align-items: flex-end;
+}
+
+.pdchat-toast-stack.toast-anchor-top-left {
+	top: 80px;
+	left: 20px;
+	align-items: flex-start;
+}
+
+/* Toast card: reuse the preview look but neutralise the legacy absolute positioning / slide-in
+   animation so the card flows inside the flex stack and is driven by the toast-* animation classes. */
+.pdchat-message-preview.pdchat-toast {
+	position: relative;
+	top: auto;
+	bottom: auto;
+	left: auto;
+	right: auto;
+	transform: none;
+	margin: 0;
+	opacity: 1;
+	cursor: pointer;
+	pointer-events: auto;
+	animation-duration: var(--pdchat-toast-anim-ms, 250ms);
+	animation-timing-function: ease-out;
+	animation-fill-mode: both;
+	will-change: transform, opacity;
+}
+
+.pdchat-toast-close {
+	position: absolute;
+	top: 2px;
+	right: 4px;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 16px;
+	line-height: 1;
+	cursor: pointer;
+	opacity: 0.5;
+	padding: 2px 4px;
+}
+
+.pdchat-toast-close:hover {
+	opacity: 1;
+}
+
+/* ---- Entry animations ---- */
+.pdchat-message-preview.pdchat-toast.toast-enter-grow {
+	animation-name: pdchat-toast-grow-in;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-enter-shrink {
+	animation-name: pdchat-toast-shrink-in;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-enter-fade {
+	animation-name: pdchat-toast-fade-in;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-enter-slide {
+	animation-name: pdchat-toast-slide-in-right;
+}
+
+.pdchat-toast-stack.toast-anchor-bottom-left .pdchat-message-preview.pdchat-toast.toast-enter-slide,
+.pdchat-toast-stack.toast-anchor-top-left .pdchat-message-preview.pdchat-toast.toast-enter-slide {
+	animation-name: pdchat-toast-slide-in-left;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-enter-none {
+	animation-name: none;
+	opacity: 1;
+}
+
+/* ---- Exit animations ---- */
+.pdchat-message-preview.pdchat-toast.toast-exit-shrink {
+	animation-name: pdchat-toast-shrink-out;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-exit-grow {
+	animation-name: pdchat-toast-grow-out;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-exit-fade {
+	animation-name: pdchat-toast-fade-out;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-exit-slide {
+	animation-name: pdchat-toast-slide-out-right;
+}
+
+.pdchat-toast-stack.toast-anchor-bottom-left .pdchat-message-preview.pdchat-toast.toast-exit-slide,
+.pdchat-toast-stack.toast-anchor-top-left .pdchat-message-preview.pdchat-toast.toast-exit-slide {
+	animation-name: pdchat-toast-slide-out-left;
+}
+
+.pdchat-message-preview.pdchat-toast.toast-exit-none {
+	animation-name: none;
+	opacity: 0;
+}
+
+/* ---- Fixed de-stack animation (uniform, independent of per-message config) ---- */
+.pdchat-message-preview.pdchat-toast.toast-destack {
+	animation-name: pdchat-toast-destack;
+	animation-duration: 250ms; /* fixed */
+	animation-timing-function: ease-in;
+}
+
+@keyframes pdchat-toast-grow-in {
+	from { opacity: 0; transform: scale(0.6); }
+	to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes pdchat-toast-grow-out {
+	from { opacity: 1; transform: scale(1); }
+	to { opacity: 0; transform: scale(1.3); }
+}
+
+@keyframes pdchat-toast-shrink-in {
+	from { opacity: 0; transform: scale(1.3); }
+	to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes pdchat-toast-shrink-out {
+	from { opacity: 1; transform: scale(1); }
+	to { opacity: 0; transform: scale(0.6); }
+}
+
+@keyframes pdchat-toast-fade-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes pdchat-toast-fade-out {
+	from { opacity: 1; }
+	to { opacity: 0; }
+}
+
+@keyframes pdchat-toast-slide-in-right {
+	from { opacity: 0; transform: translateX(30px); }
+	to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes pdchat-toast-slide-out-right {
+	from { opacity: 1; transform: translateX(0); }
+	to { opacity: 0; transform: translateX(30px); }
+}
+
+@keyframes pdchat-toast-slide-in-left {
+	from { opacity: 0; transform: translateX(-30px); }
+	to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes pdchat-toast-slide-out-left {
+	from { opacity: 1; transform: translateX(0); }
+	to { opacity: 0; transform: translateX(-30px); }
+}
+
+@keyframes pdchat-toast-destack {
+	from { opacity: 1; transform: scale(1); }
+	to { opacity: 0; transform: scale(0.85) translateY(-6px); }
+}
+
+/* Respect reduced-motion: collapse all toast animations to a simple fade. */
+@media (prefers-reduced-motion: reduce) {
+	.pdchat-message-preview.pdchat-toast[class*="toast-enter-"] {
+		animation-name: pdchat-toast-fade-in;
+	}
+
+	.pdchat-message-preview.pdchat-toast[class*="toast-exit-"],
+	.pdchat-message-preview.pdchat-toast.toast-destack {
+		animation-name: pdchat-toast-fade-out;
+	}
+}

--- a/PanoramicData.Blazor/PDMessages.razor
+++ b/PanoramicData.Blazor/PDMessages.razor
@@ -17,17 +17,24 @@
 			}
 		}
 	</div>
-	<div class="chat-input-container">
-		<textarea
-			@key="_inputKey"
-			@ref="_inputRef"
-			value="@_localInput"
-			@oninput="OnInputChanged"
-			placeholder="Type a message..."
-			rows="3"
-			disabled="@(!IsLive)"></textarea>
-		<button class="submit-button @(CanSendLocal ? string.Empty : "submit-button-disabled")" @onclick="OnSendClickedInternal" disabled="@(!CanSendLocal)">Send</button>
-	</div>
+	@if (IsInputPermitted)
+	{
+		<div class="chat-input-container">
+			<textarea
+				@key="_inputKey"
+				@ref="_inputRef"
+				value="@_localInput"
+				@oninput="OnInputChanged"
+				placeholder="Type a message..."
+				rows="3"
+				disabled="@(!IsLive)"></textarea>
+			<button class="submit-button @(CanSendLocal ? string.Empty : "submit-button-disabled")" @onclick="OnSendClickedInternal" disabled="@(!CanSendLocal)">Send</button>
+		</div>
+	}
+	else if (!string.IsNullOrWhiteSpace(InputDisabledMessage))
+	{
+		<div class="chat-input-disabled" role="note">@InputDisabledMessage</div>
+	}
 </div>
 
 

--- a/PanoramicData.Blazor/PDMessages.razor.cs
+++ b/PanoramicData.Blazor/PDMessages.razor.cs
@@ -36,6 +36,20 @@ public partial class PDMessages : IAsyncDisposable
 	[Parameter] public bool CanSend { get; set; }
 
 	/// <summary>
+	/// Gets or sets whether the message input (text area and send button) is rendered.
+	/// When false, the input is hidden and, if <see cref="InputDisabledMessage"/> is set,
+	/// that message is shown in its place. Defaults to true.
+	/// </summary>
+	[Parameter] public bool IsInputPermitted { get; set; } = true;
+
+	/// <summary>
+	/// Gets or sets an optional message shown where the input would normally appear when
+	/// <see cref="IsInputPermitted"/> is false. When null or empty, nothing is rendered in
+	/// place of the input. Rendered as plain text.
+	/// </summary>
+	[Parameter] public string? InputDisabledMessage { get; set; }
+
+	/// <summary>
 	/// An event callback that is invoked when the send button is clicked.
 	/// </summary>
 	[Parameter] public EventCallback OnSendClicked { get; set; }
@@ -83,7 +97,7 @@ public partial class PDMessages : IAsyncDisposable
 	private DotNetObjectReference<PDMessages>? _dotNetRef;
 	private bool _enterHandlerAttached;
 
-	private bool CanSendLocal => IsLive && !string.IsNullOrWhiteSpace(_localInput);
+	private bool CanSendLocal => IsInputPermitted && IsLive && !string.IsNullOrWhiteSpace(_localInput);
 
 	/// <summary>
 	/// Clears the textarea. Called by the parent after a message is sent.

--- a/PanoramicData.Blazor/PDMessages.razor.css
+++ b/PanoramicData.Blazor/PDMessages.razor.css
@@ -116,6 +116,20 @@
 	background-color: #6c757d;
 }
 
+/* Message shown in place of the input when input is not permitted (IsInputPermitted = false) */
+.chat-input-disabled {
+	flex-shrink: 0;
+	margin-top: auto;
+	padding: 12px 16px;
+	font-size: 0.85rem;
+	font-style: italic;
+	line-height: 1.35;
+	text-align: center;
+	color: #6c757d;
+	background: #f5f7fa;
+	border-top: 1px solid rgb(0 0 0 / 0.1);
+}
+
 /* ==============================================
    DARK MODE - Messages Area and Input Styling
    ============================================== */
@@ -191,5 +205,11 @@
 	
 	.submit-button-disabled:hover {
 		background-color: #343a40 !important;
+	}
+
+	.chat-input-disabled {
+		color: #adb5bd;
+		background: #373b3e;
+		border-top-color: rgb(255 255 255 / 0.1);
 	}
 }

--- a/PanoramicData.Blazor/Services/DumbChatService.cs
+++ b/PanoramicData.Blazor/Services/DumbChatService.cs
@@ -15,6 +15,8 @@ public class DumbChatService : IChatService, IDisposable
 	private bool _isMaximizePermitted = true;
 	private bool _isCanvasUsePermitted = true;
 	private bool _isClearPermitted = true;
+	private bool _isInputPermitted = true;
+	private string? _inputDisabledMessage;
 	private bool _autoRestoreOnNewMessage;
 	private bool _useFullWidthMessages = true;
 	private MessageMetadataDisplayMode _messageMetadataDisplayMode = MessageMetadataDisplayMode.UserOnlyOnRightOthersOnLeft;
@@ -25,8 +27,19 @@ public class DumbChatService : IChatService, IDisposable
 	private string _title = "Demo Chat";
 	private PDChatDockMode _restoreMode = PDChatDockMode.BottomRight;
 	private PDChatButtonPosition _minimizedButtonPosition = PDChatButtonPosition.BottomRight;
-	private bool _showLastMessage = true;
-	private double _showLastMessageDurationSeconds = 5.0;
+	private bool _toastEnabled = true;
+	private double _toastDisplayDurationSeconds = 5.0;
+	private PDChatToastAnimation _toastEntryAnimation = PDChatToastAnimation.Grow;
+	private PDChatToastAnimation _toastExitAnimation = PDChatToastAnimation.Shrink;
+	private double _toastAnimationDurationMs = 250d;
+	private bool _toastAutoDismiss = true;
+	private bool _toastShowTitle = true;
+	private string _toastMinWidth = "200px";
+	private string _toastMaxWidth = "300px";
+	private string _toastMinHeight = string.Empty;
+	private string _toastMaxHeight = string.Empty;
+	private int _toastMaxVisible = 5;
+	private PDChatButtonPosition _toastAnchor = PDChatButtonPosition.BottomRight;
 
 	private readonly List<ChatMessage> _messages = [];
 
@@ -157,6 +170,34 @@ public class DumbChatService : IChatService, IDisposable
 	}
 
 	/// <inheritdoc />
+	public bool IsInputPermitted
+	{
+		get => _isInputPermitted;
+		set
+		{
+			if (_isInputPermitted != value)
+			{
+				_isInputPermitted = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public string? InputDisabledMessage
+	{
+		get => _inputDisabledMessage;
+		set
+		{
+			if (_inputDisabledMessage != value)
+			{
+				_inputDisabledMessage = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
 	public bool AutoRestoreOnNewMessage
 	{
 		get => _autoRestoreOnNewMessage;
@@ -255,28 +296,198 @@ public class DumbChatService : IChatService, IDisposable
 	}
 
 	/// <inheritdoc />
+	[Obsolete("Superseded by ToastEnabled.")]
 	public bool ShowLastMessage
 	{
-		get => _showLastMessage;
+		get => ToastEnabled;
+		set => ToastEnabled = value;
+	}
+
+	/// <inheritdoc />
+	[Obsolete("Superseded by ToastDisplayDurationSeconds.")]
+	public double ShowLastMessageDurationSeconds
+	{
+		get => ToastDisplayDurationSeconds;
+		set => ToastDisplayDurationSeconds = value;
+	}
+
+	/// <inheritdoc />
+	public bool ToastEnabled
+	{
+		get => _toastEnabled;
 		set
 		{
-			if (_showLastMessage != value)
+			if (_toastEnabled != value)
 			{
-				_showLastMessage = value;
+				_toastEnabled = value;
 				OnConfigurationChanged?.Invoke();
 			}
 		}
 	}
 
 	/// <inheritdoc />
-	public double ShowLastMessageDurationSeconds
+	public double ToastDisplayDurationSeconds
 	{
-		get => _showLastMessageDurationSeconds;
+		get => _toastDisplayDurationSeconds;
 		set
 		{
-			if (Math.Abs(_showLastMessageDurationSeconds - value) > 0.001)
+			if (Math.Abs(_toastDisplayDurationSeconds - value) > 0.001)
 			{
-				_showLastMessageDurationSeconds = value;
+				_toastDisplayDurationSeconds = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public PDChatToastAnimation ToastEntryAnimation
+	{
+		get => _toastEntryAnimation;
+		set
+		{
+			if (_toastEntryAnimation != value)
+			{
+				_toastEntryAnimation = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public PDChatToastAnimation ToastExitAnimation
+	{
+		get => _toastExitAnimation;
+		set
+		{
+			if (_toastExitAnimation != value)
+			{
+				_toastExitAnimation = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public double ToastAnimationDurationMs
+	{
+		get => _toastAnimationDurationMs;
+		set
+		{
+			if (Math.Abs(_toastAnimationDurationMs - value) > 0.001)
+			{
+				_toastAnimationDurationMs = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public bool ToastAutoDismiss
+	{
+		get => _toastAutoDismiss;
+		set
+		{
+			if (_toastAutoDismiss != value)
+			{
+				_toastAutoDismiss = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public bool ToastShowTitle
+	{
+		get => _toastShowTitle;
+		set
+		{
+			if (_toastShowTitle != value)
+			{
+				_toastShowTitle = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public string ToastMinWidth
+	{
+		get => _toastMinWidth;
+		set
+		{
+			if (_toastMinWidth != value)
+			{
+				_toastMinWidth = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public string ToastMaxWidth
+	{
+		get => _toastMaxWidth;
+		set
+		{
+			if (_toastMaxWidth != value)
+			{
+				_toastMaxWidth = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public string ToastMinHeight
+	{
+		get => _toastMinHeight;
+		set
+		{
+			if (_toastMinHeight != value)
+			{
+				_toastMinHeight = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public string ToastMaxHeight
+	{
+		get => _toastMaxHeight;
+		set
+		{
+			if (_toastMaxHeight != value)
+			{
+				_toastMaxHeight = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public int ToastMaxVisible
+	{
+		get => _toastMaxVisible;
+		set
+		{
+			if (_toastMaxVisible != value)
+			{
+				_toastMaxVisible = value;
+				OnConfigurationChanged?.Invoke();
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public PDChatButtonPosition ToastAnchor
+	{
+		get => _toastAnchor;
+		set
+		{
+			if (_toastAnchor != value)
+			{
+				_toastAnchor = value;
 				OnConfigurationChanged?.Invoke();
 			}
 		}


### PR DESCRIPTION
Closes #82.

## What
Adds a supported way to disable the interactive **PDChat** message input so the component can run as a **notifications-only ("toast-only") surface**, with an optional developer-configurable message shown where the input would be.

## API (non-breaking)
Two **default-implemented** `IChatService` members:
- `bool IsInputPermitted` (default `true`) — when `false`, the text area + Send button are not rendered.
- `string? InputDisabledMessage` (default `null`) — when set (and input not permitted), shown in the input's place; when null/empty, nothing is shown (pure toast-only).

Defaults reproduce today's behaviour exactly, so existing `IChatService` implementers need no changes.

## Behaviour
| `IsInputPermitted` | `InputDisabledMessage` | Result |
|---|---|---|
| `true` (default) | (ignored) | Normal input — unchanged |
| `false` | null/empty (default) | Input not rendered; notifications-only, nothing shown |
| `false` | non-empty | Input replaced by the message |

## Changes
- `IChatService`: new default-implemented members.
- `PDChat` → `PDMessages`: params plumbed through; `CanSend`/`CanSendLocal` gated.
- `PDMessages.razor`: renders input / message / nothing; `PDMessages.razor.css`: disabled-message styling (light + dark).
- `DumbChatService` + demo `PDChatPage`: concrete impl and two live controls ("Enable Message Input", "Input Disabled Message").

## Verification
- `dotnet build` of library + demo: **0 errors** (`TreatWarningsAsErrors` on).
- Demo host served at `/pdchat`; toggling input off hides the box while toasts keep working; a message appears when configured.

> Note: this branch also carries in-progress toast-API work that was already present in the working tree at branch-creation time (richer `Toast*` members, toast stack rendering, `ChatToastOptions`/`PDChatToastAnimation` models, demo docs). It is included here per the maintainer's instruction rather than split out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
