### PR TITLE
PDForm: disarm beforeunload prompt on dispose (fixes #86)

### DIFF
--- a/PanoramicData.Blazor/PDForm.razor.cs
+++ b/PanoramicData.Blazor/PDForm.razor.cs
@@ -1071,6 +1071,21 @@ public partial class PDForm<TItem> : IAsyncDisposable where TItem : class
 			NavigationCancelService.BeforeNavigate -= NavigationService_BeforeNavigate;
 			if (_module != null)
 			{
+				if (ConfirmOnUnload)
+				{
+					try
+					{
+						// The beforeunload listener is shared, module-level state keyed by form id and
+						// outlives this component - without this disarm, a dirty form disposed by
+						// navigation leaves the "Exit and lose changes?" prompt armed for the whole tab.
+						await _module.InvokeVoidAsync("setUnloadListener", Id, false).ConfigureAwait(true);
+					}
+					catch (JSDisconnectedException)
+					{
+						// The Blazor circuit has already disconnected. The page and its listener are gone - benign; ignore.
+					}
+				}
+
 				await _module.DisposeAsync().ConfigureAwait(true);
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #86: PDForm registers a browser beforeunload prompt when the form becomes dirty (ConfirmOnUnload, default true), but DisposeAsync never unregistered it. Any page that disposed a dirty PDForm (for example by internal navigation) left the unconditional "Exit and lose changes?" prompt installed on the whole browser tab until a full page reload.

## Change

DisposeAsync now calls setUnloadListener(Id, false) before disposing the JS module, guarded by ConfirmOnUnload, catching JSDisconnectedException for the case where the browser or circuit is already gone. This matches the teardown idiom already used by PDModal. Removing an id that was never armed is a no-op in the JS module, so the call is safe unconditionally.

The issue's optional belt-and-braces suggestion (path-aware JS listener) was deliberately not taken: it would suppress legitimate prompts for a form that survives navigation, for example one hosted in a shared layout, which is a behaviour change beyond the bug.

## Verification

Reproduced and verified in the PanoramicData.Blazor.Web Blazor Server host:

1. Instrumented window.addEventListener/removeEventListener to log beforeunload handler changes by function name.
2. Edited a field on /pdform4 (default ConfirmOnUnload): logged `add:beforeUnloadListener`.
3. Navigated internally away via a plain anchor (bypassing PDNavLink's NavigationCancelService confirm): with this fix the disposal logged `remove:beforeUnloadListener`, and a synthetic beforeunload dispatch confirmed no prompt remains armed.

Library builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)