### PR TITLE
PDColorPicker: cancel restores the caller's colour

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,5 +29,6 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-  </ItemGroup>
+      <PackageVersion Include="bunit" Version="2.9.0" />
+</ItemGroup>
 </Project>

--- a/PanoramicData.Blazor.Test/PDColorPickerTests.cs
+++ b/PanoramicData.Blazor.Test/PDColorPickerTests.cs
@@ -1,0 +1,118 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using PanoramicData.Blazor.Models.ColorPicker;
+using Shouldly;
+using Xunit;
+
+namespace PanoramicData.Blazor.Test;
+
+/// <summary>
+/// Tests for <see cref="PDColorPicker"/>.
+/// </summary>
+/// <remarks>
+/// Issue #99. The component takes a colour in and hands one back through a callback, and the
+/// defect was entirely in what it handed back - so these assert on the values the caller
+/// receives rather than on the markup.
+/// </remarks>
+public class PDColorPickerTests : BunitContext
+{
+	/// <summary>
+	/// Sets up the rendering context.
+	/// </summary>
+	public PDColorPickerTests()
+		// The picker imports a JavaScript module for pointer tracking. Loose mode returns a
+		// stub for it, which is all these tests need: none of them drag anything.
+		=> JSInterop.Mode = JSRuntimeMode.Loose;
+
+	/// <summary>
+	/// Renders a picker and records every value it reports back.
+	/// </summary>
+	private (IRenderedComponent<PDColorPicker> Component, List<string> Reported) Render(string initial)
+	{
+		var reported = new List<string>();
+		var component = base.Render<PDColorPicker>(parameters => parameters
+			.Add(p => p.Value, initial)
+			.Add(p => p.ValueChanged, value => reported.Add(value)));
+
+		return (component, reported);
+	}
+
+	private static void Open(IRenderedComponent<PDColorPicker> component)
+		=> component.Find(".pd-color-picker-button").Click();
+
+	/// <summary>
+	/// Changes the red channel through its input, which is one of the paths that reports an
+	/// intermediate value while the popup is still open.
+	/// </summary>
+	private static void SetRed(IRenderedComponent<PDColorPicker> component, string value)
+		=> component.FindAll(".pd-color-input")[0].Change(value);
+
+	/// <summary>
+	/// Cancelling puts back the colour the caller started with.
+	/// </summary>
+	[Fact]
+	public void Cancel_RestoresTheColourTheCallerStartedWith()
+	{
+		// Issue #99: live preview reports each intermediate value, and cancelling used to
+		// restore the component's own state without telling the caller - so the caller kept the
+		// colour that was being moved towards. For a caller that renders on every change, that
+		// meant cancelling kept the abandoned colour.
+		var (component, reported) = Render("#000000");
+
+		Open(component);
+		SetRed(component, "200");
+
+		reported.ShouldNotBeEmpty("live preview reports intermediate values while the popup is open");
+
+		component.FindAll(".pd-color-picker-popup button")
+			.Single(b => b.TextContent.Contains("Cancel", StringComparison.OrdinalIgnoreCase))
+			.Click();
+
+		reported[^1].ShouldBe("#000000");
+	}
+
+	/// <summary>
+	/// Confirming keeps the colour that was chosen.
+	/// </summary>
+	[Fact]
+	public void Ok_KeepsTheChosenColour()
+	{
+		// The complement of the test above: confirming has to keep the change, or "restore on
+		// cancel" could be satisfied by never reporting anything at all.
+		var (component, reported) = Render("#000000");
+
+		Open(component);
+		SetRed(component, "200");
+
+		component.FindAll(".pd-color-picker-popup button")
+			.Single(b => b.TextContent.Contains("OK", StringComparison.OrdinalIgnoreCase))
+			.Click();
+
+		reported[^1].ShouldBe("#C80000");
+	}
+
+	/// <summary>
+	/// With live preview off, cancelling reports nothing at all.
+	/// </summary>
+	[Fact]
+	public void Cancel_WithoutLivePreview_ReportsNothing()
+	{
+		// With live preview off, nothing is reported until the choice is confirmed, so
+		// cancelling has nothing to put back and must stay silent rather than reporting the
+		// original as though it were a change.
+		var reported = new List<string>();
+		var component = Render<PDColorPicker>(parameters => parameters
+			.Add(p => p.Value, "#000000")
+			.Add(p => p.Options, new ColorPickerOptions { LivePreview = false })
+			.Add(p => p.ValueChanged, value => reported.Add(value)));
+
+		Open(component);
+		SetRed(component, "200");
+
+		component.FindAll(".pd-color-picker-popup button")
+			.Single(b => b.TextContent.Contains("Cancel", StringComparison.OrdinalIgnoreCase))
+			.Click();
+
+		reported.ShouldBeEmpty();
+	}
+}

--- a/PanoramicData.Blazor.Test/PanoramicData.Blazor.Test.csproj
+++ b/PanoramicData.Blazor.Test/PanoramicData.Blazor.Test.csproj
@@ -11,6 +11,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Renders components under test, so a fix to a component can be regression-tested
+         rather than only verified by driving a real page. Added for issue #99. -->
+    <PackageReference Include="bunit" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="AwesomeAssertions.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/PanoramicData.Blazor/PDColorPicker.razor.cs
+++ b/PanoramicData.Blazor/PDColorPicker.razor.cs
@@ -1,4 +1,4 @@
-using Microsoft.JSInterop;
+﻿using Microsoft.JSInterop;
 using PanoramicData.Blazor.Models.ColorPicker;
 
 namespace PanoramicData.Blazor;
@@ -557,9 +557,20 @@ public partial class PDColorPicker : IAsyncDisposable
 		ClosePicker();
 	}
 
-	private void CancelSelection()
+	private async Task CancelSelection()
 	{
 		_currentColor = _originalColor.Clone();
+
+		// Issue #99: live preview has already pushed intermediate values to the caller as the
+		// user dragged, so cancelling has to send the original back. Restoring only the local
+		// state left the component reverted and the caller holding the colour that was being
+		// dragged towards - which, for a caller that renders on every change, meant cancelling
+		// kept the abandoned colour.
+		if (Options.LivePreview)
+		{
+			await ValueChanged.InvokeAsync(GetOutputColorValue()).ConfigureAwait(true);
+		}
+
 		ClosePicker();
 	}
 


### PR DESCRIPTION
Fixes #99.

Cancelling closed the popup and restored the component's own state but never told
the caller — so with `LivePreview` on, which is the **default**, the caller kept
the colour being dragged towards.

`_originalColor` was already captured correctly on open; it simply was not sent.
Cancel now reports it back when live preview has been sending intermediate
values, and stays silent when it has not — then there is nothing to put back, and
reporting the original would look like a change.

### How it was found, and verified

Wiring the picker into the ChartMagic demo, where every colour drives a live
chart render, so cancelling left the chart drawn in the abandoned colour.
Verified by driving the real popup: the caller's swatch read `#000000`, then
`#4D0F0F` while dragging the saturation square, then `#000000` again on cancel.

### bUnit

Added to the test project so a component fix can be regression-tested rather
than only verified by driving a page. Three tests:

| Test | Why |
|---|---|
| `Cancel_RestoresTheColourTheCallerStartedWith` | the defect |
| `Ok_KeepsTheChosenColour` | without it, "restore on cancel" could be satisfied by never reporting anything |
| `Cancel_WithoutLivePreview_ReportsNothing` | cancel must not report the original as a change |

Red-checked: with the fix reverted, exactly one of the three fails — the first.
The other two pass either way, which is what makes them useful as guards rather
than as evidence.

### Not changed here

`NotifyColorChange` is `async void`, so an exception from a caller's
`ValueChanged` handler during a drag is unobserved rather than surfacing. Worth
fixing, but it has a wider blast radius and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
