### PR TITLE
PDChat: model a conversation as a first-class object

### DIFF
--- a/PanoramicData.Blazor.Test/ChatConversationTests.cs
+++ b/PanoramicData.Blazor.Test/ChatConversationTests.cs
@@ -1,0 +1,104 @@
+using AwesomeAssertions;
+using PanoramicData.Blazor.Models;
+
+namespace PanoramicData.Blazor.Test;
+
+/// <summary>
+/// Tests for <see cref="ChatConversation"/>, the model behind PDChat's conversation history (issue #102).
+/// </summary>
+/// <remarks>
+/// Two things here are worth more than they look. The first is that <see cref="ChatConversation.Title"/>
+/// distinguishes null from empty: a host that generates titles in the background finds its work by looking
+/// for untitled conversations, and if blank and absent are the same value it either re-titles everything
+/// forever or never re-titles anything.
+///
+/// The second is <see cref="ChatConversation.DisplayName"/>. The fallback rule lives on the model precisely
+/// so that a conversation list and a conversation tab cannot disagree about what the same conversation is
+/// called - two independently-written fallbacks would drift, and the symptom would be a user renaming
+/// something in one place and seeing the old name in the other.
+/// </remarks>
+public class ChatConversationTests
+{
+	/// <summary>Verifies that a conversation needs only an id, and that everything else has a sane default.</summary>
+	[Fact]
+	public void A_new_conversation_needs_only_an_id()
+	{
+		var id = Guid.NewGuid();
+
+		var conversation = new ChatConversation { Id = id };
+
+		conversation.Id.Should().Be(id);
+		conversation.Title.Should().BeNull();
+		conversation.Preview.Should().BeNull();
+		conversation.IsArchived.Should().BeFalse();
+		conversation.MessageCount.Should().Be(0);
+	}
+
+	/// <summary>Verifies that an untitled conversation is distinguishable from one deliberately titled as blank.</summary>
+	[Fact]
+	public void An_absent_title_is_not_the_same_as_a_blank_one()
+	{
+		var untitled = new ChatConversation { Id = Guid.NewGuid() };
+		var blankTitled = new ChatConversation { Id = Guid.NewGuid(), Title = string.Empty };
+
+		untitled.IsTitled.Should().BeFalse();
+		blankTitled.IsTitled.Should().BeTrue();
+	}
+
+	/// <summary>Verifies that a title, when there is one, is what the conversation is called.</summary>
+	[Fact]
+	public void The_title_is_the_display_name_when_there_is_one()
+	{
+		var conversation = new ChatConversation
+		{
+			Id = Guid.NewGuid(),
+			Title = "Guest network SSID",
+			Preview = "why can nobody connect to the guest network"
+		};
+
+		conversation.DisplayName.Should().Be("Guest network SSID");
+	}
+
+	/// <summary>Verifies that an untitled conversation is still identifiable, by its opening message.</summary>
+	[Fact]
+	public void An_untitled_conversation_falls_back_to_its_preview()
+	{
+		var conversation = new ChatConversation
+		{
+			Id = Guid.NewGuid(),
+			Preview = "why can nobody connect to the guest network"
+		};
+
+		conversation.DisplayName.Should().Be("why can nobody connect to the guest network");
+	}
+
+	/// <summary>
+	/// Verifies that a title of only whitespace falls back too. It is distinguishable from absent for the
+	/// titling job, but it is not something a user can read off a list.
+	/// </summary>
+	[Fact]
+	public void A_whitespace_title_falls_back_to_the_preview()
+	{
+		var conversation = new ChatConversation
+		{
+			Id = Guid.NewGuid(),
+			Title = "   ",
+			Preview = "why can nobody connect to the guest network"
+		};
+
+		conversation.DisplayName.Should().Be("why can nobody connect to the guest network");
+	}
+
+	/// <summary>
+	/// Verifies that a conversation with nothing to show still has a name. A brand new conversation has no
+	/// title and no messages, so this is the ordinary case at the moment a tab is opened, not an edge case.
+	/// </summary>
+	[Fact]
+	public void A_conversation_with_neither_title_nor_preview_still_has_a_name()
+	{
+		var conversation = new ChatConversation { Id = Guid.NewGuid() };
+
+		conversation.DisplayName.Should().Be(ChatConversation.UntitledDisplayName);
+		conversation.DisplayName.Should().NotBeNullOrWhiteSpace();
+	}
+}

--- a/PanoramicData.Blazor/Models/ChatConversation.cs
+++ b/PanoramicData.Blazor/Models/ChatConversation.cs
@@ -1,0 +1,112 @@
+namespace PanoramicData.Blazor.Models;
+
+/// <summary>
+/// Represents one conversation - a named, orderable collection of <see cref="ChatMessage"/> - so that a host
+/// application can offer <see cref="PanoramicData.Blazor.PDChat"/> a history of previous and current chats
+/// rather than a single flat message list.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately a plain model with no service dependency. A host backs it with whatever store it already has,
+/// and the component renders what it is handed; see <c>IChatConversationService</c> for the contract between
+/// the two.
+/// </para>
+/// <para>
+/// <b>There is no delete.</b> Neither here nor on the service that returns these. A transcript is a record of
+/// what an assistant told somebody, and a conversation is archived rather than removed - see
+/// <see cref="IsArchived"/>.
+/// </para>
+/// </remarks>
+public class ChatConversation
+{
+	/// <summary>
+	/// The name shown for a conversation that has neither a title nor anything said in it yet.
+	/// </summary>
+	/// <remarks>
+	/// Exposed rather than inlined so that a caller wanting to sort or filter untitled conversations, or a test
+	/// asserting on one, does not have to hard-code the same string and drift from it later.
+	/// </remarks>
+	public const string UntitledDisplayName = "New conversation";
+
+	/// <summary>
+	/// Gets the conversation's unique identifier.
+	/// </summary>
+	/// <remarks>
+	/// A <see cref="Guid"/> rather than an integer because this is the value that ends up in front of a browser.
+	/// A sequential integer would let anyone read a colleague's conversation by subtracting one.
+	/// </remarks>
+	public required Guid Id { get; init; }
+
+	/// <summary>
+	/// Gets or sets the conversation's title, or <c>null</c> when it has not been titled.
+	/// </summary>
+	/// <remarks>
+	/// <c>null</c> means <i>not yet titled</i> and is deliberately distinct from an empty string, which means
+	/// <i>titled, as blank</i>. A host that generates titles in the background finds its work by looking for the
+	/// former; if the two were the same value it would either re-title every conversation on every pass or never
+	/// re-title any of them. Use <see cref="IsTitled"/> rather than testing for emptiness.
+	/// </remarks>
+	public string? Title { get; set; }
+
+	/// <summary>Gets or sets the UTC time at which the conversation was started.</summary>
+	public DateTimeOffset CreatedUtc { get; set; } = DateTimeOffset.UtcNow;
+
+	/// <summary>
+	/// Gets or sets the UTC time of the most recent message in the conversation.
+	/// </summary>
+	/// <remarks>
+	/// A conversation list sorts on this rather than on <see cref="CreatedUtc"/>: the conversation a user wants
+	/// next is almost always the one they last said something in, which is not necessarily the newest one.
+	/// </remarks>
+	public DateTimeOffset LastMessageUtc { get; set; } = DateTimeOffset.UtcNow;
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the conversation has been archived.
+	/// </summary>
+	/// <remarks>
+	/// Archived means hidden from the default list, never removed and never unreadable. Interacting with an
+	/// archived conversation is expected to un-archive it, so that picking a conversation back up does not need
+	/// a second deliberate action.
+	/// </remarks>
+	public bool IsArchived { get; set; }
+
+	/// <summary>Gets or sets the number of messages in the conversation.</summary>
+	/// <remarks>Carried on the summary so that a list can render without fetching every transcript.</remarks>
+	public int MessageCount { get; set; }
+
+	/// <summary>
+	/// Gets or sets a short extract of the conversation - conventionally its opening message - or <c>null</c>
+	/// when there is nothing to show.
+	/// </summary>
+	public string? Preview { get; set; }
+
+	/// <summary>
+	/// Gets a value indicating whether a title has been set, whatever its content.
+	/// </summary>
+	/// <remarks>
+	/// Distinguishes "not yet titled" from "titled as blank". See <see cref="Title"/> for why that distinction
+	/// is load-bearing rather than pedantic.
+	/// </remarks>
+	public bool IsTitled => Title is not null;
+
+	/// <summary>
+	/// Gets the name to show for this conversation: its title, falling back to its preview, falling back to
+	/// <see cref="UntitledDisplayName"/>.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The rule lives here, on the model, so that a conversation list and a conversation tab cannot disagree
+	/// about what the same conversation is called. Two independently-written fallbacks would drift, and the
+	/// symptom would be a user renaming something in one place and still seeing the old name in the other.
+	/// </para>
+	/// <para>
+	/// A whitespace-only title falls back as though it were absent. It stays distinguishable to
+	/// <see cref="IsTitled"/>, because the titling job needs to know it was set, but it is not something a
+	/// reader can pick out of a list.
+	/// </para>
+	/// </remarks>
+	public string DisplayName
+		=> string.IsNullOrWhiteSpace(Title)
+			? string.IsNullOrWhiteSpace(Preview) ? UntitledDisplayName : Preview
+			: Title;
+}


### PR DESCRIPTION
Closes #102.

Adds `ChatConversation`, the model behind PDChat conversation history. No component or service changes yet — those follow in separate issues.

### What is here

- `Models/ChatConversation.cs` — id, title, created/last-message timestamps, archive flag, message count, preview.
- `IsTitled` — distinguishes `null` (not yet titled) from `""` (titled, as blank). A host that generates titles in the background finds its work by looking for the former; collapsing the two makes it either re-title everything on every pass or never re-title anything.
- `DisplayName` — the single fallback rule (title → preview → `"New conversation"`), on the model so a conversation list and a conversation tab cannot disagree about what the same conversation is called.
- `Models/ChatRoom.cs` deleted. It was a zero-byte placeholder, and its name suggests a multi-party room, which is not what this is.

### Testing

`ChatConversationTests` — 6 tests, written first and watched fail. Full suite 430/430 passing; library and demo both build clean in Release with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)