### PR TITLE
PDChat: make IChatService conversation-addressed

### DIFF
--- a/PanoramicData.Blazor.Test/ChatServiceConversationAddressingTests.cs
+++ b/PanoramicData.Blazor.Test/ChatServiceConversationAddressingTests.cs
@@ -1,0 +1,226 @@
+using AwesomeAssertions;
+using PanoramicData.Blazor.Interfaces;
+using PanoramicData.Blazor.Models;
+
+namespace PanoramicData.Blazor.Test;
+
+/// <summary>
+/// Tests for the conversation-addressed members added to <see cref="IChatService"/> (issue #104).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The members exist so that several conversations can be live at once. They are default interface
+/// implementations so that every existing implementation keeps compiling and behaving identically, which is the
+/// same technique the toast API already used on this interface.
+/// </para>
+/// <para>
+/// <b>The doubles are deliberately built two different ways.</b> <see cref="LegacyChatService"/> implements
+/// <i>only</i> the singular members, so the tests against it exercise the real default interface implementations
+/// rather than anything written here - a double that implemented the addressed members would confirm the test's
+/// own premise and prove nothing about the interface.
+/// <see cref="ConversationAwareChatService"/> implements the addressed members itself, and so exercises the
+/// opt-in path.
+/// </para>
+/// <para>
+/// The two negative tests matter most. A default implementation that quietly served its one transcript for an id
+/// it had never heard of would be the "reply landed in the wrong tab" bug moved out of the UI and into the
+/// interface, where it is harder to see and easier to trust.
+/// </para>
+/// </remarks>
+public class ChatServiceConversationAddressingTests
+{
+	/// <summary>
+	/// Verifies that a service written before conversations existed says so, rather than leaving a consumer to
+	/// subscribe to an addressed event that will never fire.
+	/// </summary>
+	[Fact]
+	public void A_service_that_knows_nothing_of_conversations_reports_that()
+	{
+		IChatService service = new LegacyChatService();
+
+		service.SupportsConversations.Should().BeFalse();
+	}
+
+	/// <summary>Verifies that such a service still answers for its own single, implicit conversation.</summary>
+	[Fact]
+	public void Its_single_conversation_is_reachable_by_the_implicit_id()
+	{
+		IChatService service = new LegacyChatService();
+		service.SendMessage(NewMessage("hello"));
+
+		var messages = service.GetMessages(ChatConversation.ImplicitConversationId);
+
+		messages.Should().ContainSingle();
+		messages[0].Message.Should().Be("hello");
+	}
+
+	/// <summary>
+	/// Verifies that asking for a conversation the service has never heard of yields nothing - rather than the
+	/// one transcript it happens to have.
+	/// </summary>
+	[Fact]
+	public void Reading_an_unknown_conversation_yields_nothing_rather_than_the_wrong_transcript()
+	{
+		IChatService service = new LegacyChatService();
+		service.SendMessage(NewMessage("hello"));
+
+		var messages = service.GetMessages(Guid.NewGuid());
+
+		messages.Should().BeEmpty();
+	}
+
+	/// <summary>Verifies that sending to the implicit conversation reaches the underlying single-conversation send.</summary>
+	[Fact]
+	public void Sending_to_the_implicit_conversation_reaches_the_service()
+	{
+		var service = new LegacyChatService();
+
+		((IChatService)service).SendMessage(ChatConversation.ImplicitConversationId, NewMessage("hello"));
+
+		service.Messages.Should().ContainSingle();
+		service.Messages[0].Message.Should().Be("hello");
+	}
+
+	/// <summary>
+	/// Verifies that sending to an unknown conversation fails loudly instead of delivering to the wrong one.
+	/// </summary>
+	/// <remarks>
+	/// Silent misdelivery is the whole failure this work exists to prevent. A caller addressing a conversation
+	/// the service does not have has a bug, and it should surface where it happened rather than as a message
+	/// appearing in somebody else's tab several seconds later.
+	/// </remarks>
+	[Fact]
+	public void Sending_to_an_unknown_conversation_throws_rather_than_misdelivering()
+	{
+		var service = new LegacyChatService();
+
+		var send = () => ((IChatService)service).SendMessage(Guid.NewGuid(), NewMessage("hello"));
+
+		send.Should().Throw<InvalidOperationException>();
+		service.Messages.Should().BeEmpty();
+	}
+
+	/// <summary>Verifies that a conversation-aware service opts in and keeps its transcripts apart.</summary>
+	[Fact]
+	public void A_conversation_aware_service_keeps_transcripts_apart()
+	{
+		var alpha = Guid.NewGuid();
+		var beta = Guid.NewGuid();
+		IChatService service = new ConversationAwareChatService(alpha, beta);
+
+		service.SupportsConversations.Should().BeTrue();
+		service.SendMessage(alpha, NewMessage("about the guest network"));
+		service.SendMessage(beta, NewMessage("about the firewall"));
+
+		service.GetMessages(alpha).Should().ContainSingle().Which.Message.Should().Be("about the guest network");
+		service.GetMessages(beta).Should().ContainSingle().Which.Message.Should().Be("about the firewall");
+	}
+
+	/// <summary>
+	/// Verifies that a reply for a background conversation is reported with the id that asked for it, so that a
+	/// consumer can route it without guessing at "the current one".
+	/// </summary>
+	[Fact]
+	public void A_reply_is_reported_against_the_conversation_that_asked_for_it()
+	{
+		var alpha = Guid.NewGuid();
+		var beta = Guid.NewGuid();
+		var service = new ConversationAwareChatService(alpha, beta);
+		var received = new List<(Guid ConversationId, string Message)>();
+		((IChatService)service).OnConversationMessageReceived += (id, m) => received.Add((id, m.Message));
+
+		service.Receive(beta, "the firewall is fine");
+
+		received.Should().ContainSingle();
+		received[0].ConversationId.Should().Be(beta);
+		received[0].Message.Should().Be("the firewall is fine");
+	}
+
+	/// <summary>
+	/// Verifies that the active conversation of a service that knows nothing of conversations is the implicit
+	/// one, so that a consumer has a single id it can always address.
+	/// </summary>
+	[Fact]
+	public void The_implicit_conversation_is_active_by_default()
+	{
+		IChatService service = new LegacyChatService();
+
+		service.ActiveConversationId.Should().Be(ChatConversation.ImplicitConversationId);
+	}
+
+	private static ChatMessage NewMessage(string text) => new()
+	{
+		Id = Guid.NewGuid(),
+		Sender = new ChatMessageSender { Name = "User", IsUser = true, IsHuman = true },
+		Message = text,
+		Type = MessageType.Normal
+	};
+
+	/// <summary>
+	/// A minimal <see cref="IChatService"/> implementing <i>only</i> the singular members, standing in for every
+	/// implementation written before conversations existed. It deliberately does not implement any
+	/// conversation-addressed member, so tests against it exercise the interface's own defaults.
+	/// </summary>
+	private sealed class LegacyChatService : TestChatServiceBase
+	{
+		private readonly List<ChatMessage> _messages = [];
+
+		public override IReadOnlyList<ChatMessage> Messages => _messages;
+
+		public override void SendMessage(ChatMessage chatMessage) => _messages.Add(chatMessage);
+
+		public override void ClearMessages() => _messages.Clear();
+	}
+
+	/// <summary>
+	/// A minimal <see cref="IChatService"/> that opts in to conversations and holds a transcript per conversation.
+	/// </summary>
+	/// <remarks>
+	/// Note the repeated <see cref="IChatService"/> in the base list. It is not redundant: the interface mapping
+	/// is fixed at <see cref="TestChatServiceBase"/>, so without re-stating the interface here these members
+	/// would be ordinary class members and a caller holding an <see cref="IChatService"/> would silently get the
+	/// defaults instead. That trap is documented on the interface itself.
+	/// </remarks>
+	private sealed class ConversationAwareChatService : TestChatServiceBase, IChatService
+	{
+		private readonly Dictionary<Guid, List<ChatMessage>> _byConversation;
+
+		public ConversationAwareChatService(params Guid[] conversationIds)
+		{
+			_byConversation = conversationIds.ToDictionary(x => x, _ => new List<ChatMessage>());
+			ActiveConversationId = conversationIds[0];
+		}
+
+		public bool SupportsConversations => true;
+
+		public Guid ActiveConversationId { get; set; }
+
+		public event Action<Guid, ChatMessage>? OnConversationMessageReceived;
+
+		public override IReadOnlyList<ChatMessage> Messages => GetMessages(ActiveConversationId);
+
+		public IReadOnlyList<ChatMessage> GetMessages(Guid conversationId)
+			=> _byConversation.TryGetValue(conversationId, out var messages) ? messages : [];
+
+		public void SendMessage(Guid conversationId, ChatMessage chatMessage)
+		{
+			if (!_byConversation.TryGetValue(conversationId, out var messages))
+			{
+				throw new InvalidOperationException($"Unknown conversation {conversationId}.");
+			}
+
+			messages.Add(chatMessage);
+		}
+
+		public override void SendMessage(ChatMessage chatMessage) => SendMessage(ActiveConversationId, chatMessage);
+
+		public override void ClearMessages() => _byConversation[ActiveConversationId].Clear();
+
+		public void Receive(Guid conversationId, string text)
+		{
+			var message = NewMessage(text);
+			_byConversation[conversationId].Add(message);
+			OnConversationMessageReceived?.Invoke(conversationId, message);
+		}
+	}
+}

--- a/PanoramicData.Blazor.Test/TestChatServiceBase.cs
+++ b/PanoramicData.Blazor.Test/TestChatServiceBase.cs
@@ -1,0 +1,129 @@
+using PanoramicData.Blazor.Interfaces;
+using PanoramicData.Blazor.Models;
+
+namespace PanoramicData.Blazor.Test;
+
+/// <summary>
+/// Boilerplate for an <see cref="IChatService"/> test double: implements the presentation and configuration
+/// members that every implementation is obliged to supply, leaving a derived double to say only what its test
+/// is about.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This deliberately implements <b>only the members <see cref="IChatService"/> requires</b>. It does not touch
+/// any member that carries a default interface implementation - not the toast API and not the
+/// conversation-addressed members - because a double that supplied its own version of those would make tests
+/// pass by agreeing with themselves rather than by exercising the interface.
+/// </para>
+/// <para>
+/// Test-only, and so it lives in the test project rather than beside the production services.
+/// </para>
+/// </remarks>
+public abstract class TestChatServiceBase : IChatService
+{
+	/// <inheritdoc />
+	public bool IsLive { get; set; } = true;
+
+	/// <inheritdoc />
+	public PDChatDockMode DockMode { get; set; } = PDChatDockMode.BottomRight;
+
+	/// <inheritdoc />
+	public PDChatDockMode PreferredDockMode { get; set; } = PDChatDockMode.BottomRight;
+
+	/// <inheritdoc />
+	public PDChatDockMode RestoreMode { get; set; } = PDChatDockMode.BottomRight;
+
+	/// <inheritdoc />
+	public PDChatButtonPosition MinimizedButtonPosition { get; set; } = PDChatButtonPosition.BottomRight;
+
+	/// <inheritdoc />
+	public bool IsMuted { get; set; }
+
+	/// <inheritdoc />
+	public string Title { get; set; } = "Test Chat";
+
+	/// <inheritdoc />
+	public bool IsMaximizePermitted { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool IsCanvasUsePermitted { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool IsClearPermitted { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool AutoRestoreOnNewMessage { get; set; }
+
+	/// <inheritdoc />
+	public bool UseFullWidthMessages { get; set; } = true;
+
+	/// <inheritdoc />
+	public MessageMetadataDisplayMode MessageMetadataDisplayMode { get; set; }
+		= MessageMetadataDisplayMode.UserOnlyOnRightOthersOnLeft;
+
+	/// <inheritdoc />
+	public bool ShowMessageUserIcon { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool ShowMessageUserName { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool ShowMessageTimestamp { get; set; } = true;
+
+	/// <inheritdoc />
+	public string MessageTimestampFormat { get; set; } = "HH:mm:ss";
+
+	/// <inheritdoc />
+	[Obsolete("Required by the interface for backward compatibility; superseded by the toast API.")]
+	public bool ShowLastMessage { get; set; } = true;
+
+	/// <inheritdoc />
+	[Obsolete("Required by the interface for backward compatibility; superseded by the toast API.")]
+	public double ShowLastMessageDurationSeconds { get; set; } = 5d;
+
+	/// <inheritdoc />
+	public abstract IReadOnlyList<ChatMessage> Messages { get; }
+
+	/// <inheritdoc />
+	public event Action<ChatMessage>? OnMessageReceived;
+
+	/// <inheritdoc />
+	public event Action<bool>? OnLiveStatusChanged;
+
+	/// <inheritdoc />
+	public event Action<PDChatDockMode>? OnDockModeChanged;
+
+	/// <inheritdoc />
+	public event Action<bool>? OnMuteStatusChanged;
+
+	/// <inheritdoc />
+	public event Action? OnConfigurationChanged;
+
+	/// <inheritdoc />
+	public abstract void SendMessage(ChatMessage chatMessage);
+
+	/// <inheritdoc />
+	public abstract void ClearMessages();
+
+	/// <inheritdoc />
+	public void Initialize()
+	{
+	}
+
+	/// <inheritdoc />
+	public void Dispose() => GC.SuppressFinalize(this);
+
+	/// <summary>
+	/// Raises <see cref="OnMessageReceived"/>. Present so that the events above are not merely declared and
+	/// never used, which the compiler would otherwise warn about, and so a double can simulate an inbound
+	/// message on the singular path.
+	/// </summary>
+	protected void RaiseMessageReceived(ChatMessage message)
+	{
+		OnMessageReceived?.Invoke(message);
+		OnLiveStatusChanged?.Invoke(IsLive);
+		OnDockModeChanged?.Invoke(DockMode);
+		OnMuteStatusChanged?.Invoke(IsMuted);
+		OnConfigurationChanged?.Invoke();
+	}
+}

--- a/PanoramicData.Blazor/Interfaces/IChatService.cs
+++ b/PanoramicData.Blazor/Interfaces/IChatService.cs
@@ -260,6 +260,103 @@ public interface IChatService
 	/// </summary>
 	IReadOnlyList<ChatMessage> Messages { get; }
 
+	// ==========================================================================================
+	// Conversation-addressed API
+	//
+	// Everything above is singular: one Messages list, one SendMessage, one OnMessageReceived. A host that
+	// wants several conversations open at once - tabs, say - has no way to say which conversation a message
+	// belongs to, so a reply arriving from any of them appends to whichever transcript happens to be selected.
+	// That failure is intermittent, depends on timing, and presents as a rendering bug.
+	//
+	// The members below address a conversation explicitly. All carry default interface implementations that map
+	// onto the singular members using a single implicit conversation, so every existing implementation compiles
+	// and behaves identically - the same technique the toast API above already uses.
+	//
+	// The defaults deliberately REFUSE an unrecognised conversation id rather than falling back to the single
+	// conversation. Serving the one transcript a service has, for an id it has never heard of, would be the
+	// misdelivery bug moved out of the UI and into the interface, where it is harder to see.
+	//
+	// TRAP WHEN OPTING IN FROM A DERIVED CLASS. If a base class already implements IChatService, adding these
+	// members to a class derived from it is NOT enough - the interface mapping was fixed at the base, so the new
+	// members are ordinary class members and a caller holding an IChatService still gets the defaults. Nothing
+	// warns about it: the type compiles, the members exist, and SupportsConversations reads true off the concrete
+	// type and false off the interface. Re-state the interface in the derived type's base list
+	// (class MyService : MyServiceBase, IChatService) so that the members bind.
+	// ==========================================================================================
+
+	/// <summary>
+	/// Gets a value indicating whether this service can hold more than one conversation at a time.
+	/// Defaults to <c>false</c>.
+	/// </summary>
+	/// <remarks>
+	/// A consumer must check this before relying on <see cref="OnConversationMessageReceived"/>, whose default
+	/// implementation accepts subscriptions and never fires. Without the flag a consumer would subscribe, see
+	/// nothing, and have no way to tell that from a service that simply had no traffic.
+	/// </remarks>
+	bool SupportsConversations => false;
+
+	/// <summary>
+	/// Gets or sets the conversation currently being shown. Defaults to
+	/// <see cref="ChatConversation.ImplicitConversationId"/>, and the setter is ignored, for a service that does
+	/// not support conversations.
+	/// </summary>
+	Guid ActiveConversationId
+	{
+		get => ChatConversation.ImplicitConversationId;
+		set { }
+	}
+
+	/// <summary>
+	/// Gets the messages belonging to one conversation, or an empty list if this service does not have it.
+	/// </summary>
+	/// <remarks>
+	/// An unrecognised id yields nothing rather than <see cref="Messages"/>. Returning the wrong transcript
+	/// would be indistinguishable, to a caller, from the conversation genuinely containing those messages.
+	/// </remarks>
+	IReadOnlyList<ChatMessage> GetMessages(Guid conversationId)
+		=> conversationId == ActiveConversationId ? Messages : [];
+
+	/// <summary>
+	/// Sends a message to a specific conversation.
+	/// </summary>
+	/// <param name="conversationId">The conversation to send to.</param>
+	/// <param name="chatMessage">The message to send.</param>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown when this service does not have the requested conversation.
+	/// </exception>
+	/// <remarks>
+	/// Throwing is deliberate. A caller addressing a conversation the service does not have has a bug, and it
+	/// should surface where it happened rather than as a message appearing in an unrelated conversation several
+	/// seconds later.
+	/// </remarks>
+	void SendMessage(Guid conversationId, ChatMessage chatMessage)
+	{
+		if (conversationId != ActiveConversationId)
+		{
+			throw new InvalidOperationException(
+				$"This chat service does not have conversation {conversationId}. " +
+				$"It supports a single conversation ({ActiveConversationId}); check {nameof(SupportsConversations)} " +
+				"before addressing conversations individually.");
+		}
+
+		SendMessage(chatMessage);
+	}
+
+	/// <summary>
+	/// Raised when a message arrives, reporting the conversation it belongs to so that a consumer can route it
+	/// without guessing at "the current one".
+	/// </summary>
+	/// <remarks>
+	/// The default implementation accepts subscriptions and never raises, because a service that does not
+	/// support conversations has nothing to disambiguate. Check <see cref="SupportsConversations"/> and fall
+	/// back to <see cref="OnMessageReceived"/> when it is <c>false</c>.
+	/// </remarks>
+	event Action<Guid, ChatMessage>? OnConversationMessageReceived
+	{
+		add { }
+		remove { }
+	}
+
 	/// <summary>
 	/// Event triggered when a new message is received.
 	/// </summary>

--- a/PanoramicData.Blazor/Models/ChatConversation.cs
+++ b/PanoramicData.Blazor/Models/ChatConversation.cs
@@ -29,6 +29,18 @@ public class ChatConversation
 	public const string UntitledDisplayName = "New conversation";
 
 	/// <summary>
+	/// The identifier standing for the single conversation held by a chat service that does not support
+	/// conversations - see <c>IChatService.SupportsConversations</c>.
+	/// </summary>
+	/// <remarks>
+	/// A fixed, well-known value so that a consumer written against the conversation-addressed API has one id it
+	/// can always address, whether or not the service behind it knows what a conversation is. It is
+	/// deliberately not <see cref="Guid.Empty"/>: empty is what an uninitialised field holds, so a bug that
+	/// forgot to set an id would silently address the implicit conversation and appear to work.
+	/// </remarks>
+	public static readonly Guid ImplicitConversationId = new("9f2a4c3e-7b1d-4a6f-8c05-1e3d5a7b9c11");
+
+	/// <summary>
 	/// Gets the conversation's unique identifier.
 	/// </summary>
 	/// <remarks>


### PR DESCRIPTION
Closes #104. Stacked on #103 — review that one first.

Adds the conversation-addressed members to `IChatService`, all as **default interface implementations**, so every existing implementation compiles and behaves identically. Same technique the toast API already uses on this interface.

- `SupportsConversations` (defaults `false`), `ActiveConversationId`, `GetMessages(Guid)`, `SendMessage(Guid, ChatMessage)`, `OnConversationMessageReceived`.
- `ChatConversation.ImplicitConversationId` — the well-known id standing for the single conversation a non-conversation-aware service has. Deliberately not `Guid.Empty`, so a bug that forgot to set an id can't silently address it and appear to work.

### The defaults refuse unknown ids

`GetMessages` returns empty and `SendMessage` throws, rather than falling back to the single conversation. Serving the one transcript a service has, for an id it has never heard of, is the misdelivery bug moved out of the UI and into the interface — where it is harder to see and easier to trust.

### One thing worth knowing before you implement this

Writing the tests first turned up a trap. Where a base class already implements `IChatService`, adding these members to a **derived** class does not bind them — the interface mapping was fixed at the base, so they are ordinary class members and a caller holding an `IChatService` still gets the defaults.

Nothing warns about it. `SupportsConversations` reads `true` off the concrete type and `false` off the interface. The derived type must re-state the interface: `class MyService : MyServiceBase, IChatService`. Documented on the interface, and in the test double that hit it.

### Testing

`ChatServiceConversationAddressingTests` — 8 tests, written first and watched fail. The doubles are built two different ways on purpose: the legacy one implements *only* the singular members, so it exercises the real interface defaults rather than agreeing with itself.

Full suite 438/438. Library and demo build clean in Release, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)