### PR TITLE
BC-81 follow-up: stop PDTable self-clipping vertically

### DIFF
--- a/PanoramicData.Blazor/PDTable.razor.css
+++ b/PanoramicData.Blazor/PDTable.razor.css
@@ -22,11 +22,28 @@
 
 .pdtable {
 	box-sizing: border-box;
-	height: 100%;
+	height: auto;
 	max-width: 100%;
 	min-width: 0;
 	overflow-x: auto;
 	width: 100%;
+}
+
+/* BC-81 added overflow-x to contain wide columns, but left overflow-y unset. Per the CSS
+   overflow spec, pairing overflow-x:auto with an overflow-y left at its initial "visible"
+   forces the browser to compute overflow-y as auto too - so every .pdtable became implicitly
+   vertically scrollable as an unreviewed side effect. That was invisible here because
+   height was 100%, which only clips when an ancestor supplies a definite height; wherever it
+   did (e.g. a PDTable placed directly under a page element with no intervening auto-height
+   wrapper - see MS-25891 in the ReportMagic Schedules page), the table self-clipped and grew
+   its own inner vertical scrollbar on top of the page's own outer one. height:auto on the base
+   rule means the table box always matches its own content height, so it can never have "extra"
+   vertical content of its own to hide or scroll - overflow-x still works as BC-81 intended,
+   since horizontal scrolling only needs a bounded width. The opt-in MaxHeight/StickyHeader/
+   StickyPager scrollable-table mode (see PDTableStickyPage) still needs the table to fill and
+   self-scroll within its constrained .pdtable-container, so that mode keeps height:100% below. */
+.pdtable-container .pdtable {
+	height: 100%;
 }
 
 .noselect {


### PR DESCRIPTION
## Problem

BC-81 (b2fcc4d0) added `overflow-x: auto` to `.pdtable` to contain wide columns, but left `overflow-y` unset. Per the CSS overflow spec, pairing `overflow-x: auto` with an `overflow-y` still at its initial `visible` forces the browser to compute `overflow-y` as `auto` too — so every `.pdtable` became implicitly vertically scrollable as an unreviewed side effect of a horizontal-only fix.

That was invisible as long as `.pdtable`'s pre-existing `height: 100%` resolved to `auto` (which only happens when there's no ancestor with a definite height to clip against — e.g. wherever `PDTable` happens to sit behind an unsized wrapper div). Wherever it doesn't — e.g. a `PDTable` placed directly under a page element with a definite height, as in ReportMagic's Schedules page (MS-25891) — `height: 100%` now clips for real, and the table grows its own inner vertical scrollbar stacked on top of the page's own outer one: a double scrollbar.

## Fix

The base `.pdtable` rule uses `height: auto` instead of `100%`, so the table box always matches its own content height and can never have vertical overflow of its own to hide or scroll. `overflow-x: auto` (plus `box-sizing: border-box`, `max-width: 100%`, `min-width: 0`) is untouched and still contains wide columns exactly as BC-81 intended — horizontal scrolling only needs a bounded width, not a bounded height.

The opt-in `MaxHeight`/`StickyHeader`/`StickyPager` scrollable-table mode (`PDTableStickyPage`) still needs the table to fill and self-scroll within its constrained `.pdtable-container`, so `height: 100%` is restored there specifically via `.pdtable-container .pdtable`.

## Verification

- `dotnet build PanoramicData.Blazor/PanoramicData.Blazor.csproj` — clean.
- `dotnet test PanoramicData.Blazor.Test` — 438/438 passing.
- `/pdtable` demo (no `MaxHeight`): table grows to its natural content height, `scrollHeight === clientHeight`, no self-scroll.
- `/pdtable-sticky` demo: all 4 examples still self-scroll correctly with sticky header intact; the one example whose content exactly fits its `MaxHeight` correctly shows no phantom scrollbar.

Refs BC-81, MS-25891

🤖 Generated with [Claude Code](https://claude.com/claude-code)