### PR TITLE
Stop the Demo project packing on every build (fixes #114)

### DIFF
--- a/PanoramicData.Blazor.Demo/PanoramicData.Blazor.Demo.csproj
+++ b/PanoramicData.Blazor.Demo/PanoramicData.Blazor.Demo.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -12,7 +12,11 @@
     <RepositoryUrl>https://github.com/panoramicdata/PanoramicData.Blazor</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Deliberately false. version.json makes only main a public release ref, so Nerdbank.GitVersioning
+         stamps a prerelease version everywhere else; packing on every build then trips NU5104 (a stable
+         package must not carry a prerelease dependency) on every feature branch, and so on every PR build.
+         main is unaffected, which is what let this through. See issue #114. -->
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageId>PanoramicData.Blazor.Demo</PackageId>
     <NeutralResourcesLanguage>en</NeutralResourcesLanguage>


### PR DESCRIPTION
Closes #114.

**Every feature-branch build currently fails**, and therefore every PR build. `main` is fine, which is why it got through — the failure only reproduces off a branch, which is the one place PRs build.

`4508ab89` (*NuGetHygiene governance remediations*) flipped `GeneratePackageOnBuild` from `false` to `true` on the Demo. `version.json` lists only `^refs/heads/main$` as a public release ref, so NBGV stamps a stable version on `main` and a prerelease one everywhere else — packing on every build then trips NU5104 (a stable package must not carry a prerelease dependency), which `TreatWarningsAsErrors` turns into an error.

The sweep also bumped Nerdbank.GitVersioning 3.10.91 → 3.10.94, which *looks* like the culprit. **It is not** — pinning it back leaves the failure unchanged. I checked before writing this.

Restores the deliberate prior state and leaves a comment saying why, so the next sweep has something to read. If the Demo genuinely should ship as a package, that packing needs to happen in a release context rather than on every build — a separate decision, noted on the issue. Governance should also be told so the sweep does not re-apply it.

Verified: feature-branch build goes from NU5104 error to `Build succeeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)