### PR TITLE
Register the conversation history in the WASM demo host too (fixes #119)

### DIFF
--- a/PanoramicData.Blazor.Web/Program.cs
+++ b/PanoramicData.Blazor.Web/Program.cs
@@ -16,6 +16,9 @@ builder.Services.AddRazorComponents()
 
 // PanoramicData.Blazor services
 builder.Services.AddPanoramicDataBlazor();
+// Must match PanoramicData.Blazor.WebAssembly/Client/Program.cs - see issue #119: the published
+// GitHub Pages demo is built from that project, so a service registered only here is one the
+// public demo does not have.
 // One DumbChatService instance seen through three registrations rather than three instances: the
 // conversation history reads the transcripts the chat service holds, so resolving a second
 // DumbChatService for it would give the sidebar a store nothing was ever written to.

--- a/PanoramicData.Blazor.WebAssembly/Client/Program.cs
+++ b/PanoramicData.Blazor.WebAssembly/Client/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using PanoramicData.Blazor.Demo.Services;
 using PanoramicData.Blazor.Extensions;
 using PanoramicData.Blazor.Interfaces;
 using PanoramicData.Blazor.Services;
@@ -26,7 +27,17 @@ public static class Program
 
 		builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 		builder.Services.AddPanoramicDataBlazor();
-		builder.Services.AddSingleton<IChatService, DumbChatService>(); // Register the dumb chat service for demonstration purposes
+		// One DumbChatService instance seen through two registrations rather than two instances: the
+		// conversation history reads the transcripts the chat service holds, so resolving a second
+		// DumbChatService for it would give the sidebar a store nothing was ever written to.
+		//
+		// This has to match PanoramicData.Blazor.Web/Program.cs. The published GitHub Pages demo is built
+		// from THIS project, so a service registered only in the Web host is one the public demo does not
+		// have - which is how the conversation sidebar came to be invisible on the published site while
+		// working locally.
+		builder.Services.AddSingleton<DumbChatService>();
+		builder.Services.AddSingleton<IChatService>(sp => sp.GetRequiredService<DumbChatService>());
+		builder.Services.AddSingleton<IChatConversationService, DemoChatConversationService>();
 
 		await builder.Build().RunAsync().ConfigureAwait(true);
 	}


### PR DESCRIPTION
Closes #119.

The conversation sidebar and tabs from #111/#112 work locally and are **completely absent from the published demo**.

`PDChat` renders the conversation UI only when given an `IChatConversationService`, and it was registered in only one of the two demo hosts — `PanoramicData.Blazor.Web`, which is what runs locally. GitHub Pages publishes `PanoramicData.Blazor.WebAssembly/Client`, which had none. So the demo everyone actually looks at was the one host without the service.

My miss: I verified against the local Web host throughout and never against the artefact the public demo is built from.

Registers the same trio in the WASM client, with a comment in both files saying they must match and why. A shared `AddDemoServices()` extension would remove the class of bug rather than this instance — noted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)