### PR TITLE
PDChat: let a conversation be un-archived (fixes #121)

### DIFF
--- a/ComponentDocumentation.md
+++ b/ComponentDocumentation.md
@@ -261,7 +261,7 @@ Three things about it are deliberate and worth knowing before you implement one:
 - **Unread markers** — a reply arriving for a tab the user is not looking at marks that tab and does **not** steal focus. This is what makes tabs worth having when an answer can take minutes: ask, switch away, come back.
 Tabs are also renamable by double-click, which writes through to `IChatConversationService.RenameAsync`, and `PDTabSet`'s own **+** creates a new conversation.
 
-- **Toolbar** — collapse/expand the sidebar and archive the selected conversation. Archiving closes the tab, because leaving an archived conversation open and re-activating it on the next keystroke is a confusing pair of behaviours. There is no delete control, because there is no delete.
+- **Toolbar** — collapse/expand the sidebar, archive the selected conversation, and **un-archive** it. Archiving closes the tab; un-archiving deliberately does not, because the user has just said they want that conversation back. The un-archive control is *hidden* rather than disabled when the conversation is not archived — un-archiving something never archived is meaningless, not merely unavailable. **Opening an archived conversation does not un-archive it**: it stays archived until un-archived explicitly, so the archived filter is browsable rather than self-defeating. Archiving closes the tab, because leaving an archived conversation open and re-activating it on the next keystroke is a confusing pair of behaviours. There is no delete control, because there is no delete.
 
 A failing `ListAsync` degrades to a visible message in the sidebar with a retry, and leaves the transcript beside it usable.
 

--- a/PanoramicData.Blazor.Demo/Pages/PDChatDocumentation.razor
+++ b/PanoramicData.Blazor.Demo/Pages/PDChatDocumentation.razor
@@ -73,6 +73,12 @@
 				marks the tab it belongs to and does not drag you back to it.</li>
 			<li><strong>Include archived</strong> &mdash; unchecked by default. Tick it to reveal the seeded
 				archived conversation.</li>
+			<li><strong>Archive and un-archive</strong> &mdash; archiving closes the tab and drops the conversation
+				out of the default list. To get it back: tick <em>Include archived</em>, open it, and use
+				<em>Un-archive</em> in the toolbar. Opening an archived conversation does <em>not</em> silently
+				un-archive it, so you can read one without dragging it back into the list; and un-archiving leaves it
+				open, because you have just said you want it. The control is hidden, not greyed, when the
+				conversation is not archived. There is no delete, anywhere.</li>
 		</ul>
 		<p>
 			None of this appears in the docked, minimised or toast modes: the feature deliberately leaves the chat

--- a/PanoramicData.Blazor.Test/PDChatUnarchiveTests.cs
+++ b/PanoramicData.Blazor.Test/PDChatUnarchiveTests.cs
@@ -1,0 +1,177 @@
+using AwesomeAssertions;
+using Bunit;
+using PanoramicData.Blazor.Interfaces;
+using PanoramicData.Blazor.Models;
+using PanoramicData.Blazor.Services;
+
+namespace PanoramicData.Blazor.Test;
+
+/// <summary>
+/// Tests the un-archive control in the full-screen conversation toolbar (issue #121, MS-25789).
+/// </summary>
+/// <remarks>
+/// The point of these is that archiving is reversible from the UI, not merely from the API. Until this,
+/// <see cref="IChatConversationService.UnarchiveAsync"/> existed and nothing anywhere called it - so a user
+/// who archived the wrong conversation could see it (by including archived in the list) and had no way to
+/// get it back. An archive with no way back is a delete wearing a different name, which is precisely what
+/// this feature promises never to do.
+/// </remarks>
+public class PDChatUnarchiveTests : BunitContext
+{
+	/// <summary>Sets up the rendering context.</summary>
+	public PDChatUnarchiveTests() => JSInterop.Mode = JSRuntimeMode.Loose;
+
+	/// <summary>
+	/// Verifies that the control is absent for a conversation that is not archived.
+	/// </summary>
+	/// <remarks>
+	/// Hidden rather than disabled: un-archiving something never archived is meaningless, not merely
+	/// unavailable, and a permanently greyed control teaches the reader nothing.
+	/// </remarks>
+	[Fact]
+	public async Task The_control_is_absent_when_the_conversation_is_not_archived()
+	{
+		var (component, _) = await RenderFullScreenWithConversationAsync(isArchived: false);
+
+		component.Markup.Should().NotContain("Un-archive");
+	}
+
+	/// <summary>Verifies that the control appears for an archived conversation that is open.</summary>
+	/// <remarks>
+	/// This is the case the old <see cref="ChatConversation.IsArchived"/> remark would have made impossible:
+	/// it said opening an archived conversation should un-archive it, which would mean an open conversation
+	/// is never archived and the control never renders.
+	/// </remarks>
+	[Fact]
+	public async Task The_control_appears_for_an_open_archived_conversation()
+	{
+		var (component, _) = await RenderFullScreenWithConversationAsync(isArchived: true);
+
+		component.Markup.Should().Contain("Un-archive");
+	}
+
+	/// <summary>Verifies that using the control un-archives the conversation in the store.</summary>
+	[Fact]
+	public async Task Using_the_control_un_archives_the_conversation_in_the_store()
+	{
+		var (component, store) = await RenderFullScreenWithConversationAsync(isArchived: true);
+
+		await component.Find("button[title*='Un-archive']").ClickAsync(new());
+
+		store.Unarchived.Should().ContainSingle().Which.Should().Be(store.ConversationId);
+		store.Conversation.IsArchived.Should().BeFalse();
+	}
+
+	/// <summary>
+	/// Verifies that the control disappears once used, without needing the list to be reloaded first.
+	/// </summary>
+	[Fact]
+	public async Task The_control_disappears_once_the_conversation_is_un_archived()
+	{
+		var (component, _) = await RenderFullScreenWithConversationAsync(isArchived: true);
+
+		await component.Find("button[title*='Un-archive']").ClickAsync(new());
+
+		component.Markup.Should().NotContain("Un-archive");
+	}
+
+	/// <summary>
+	/// Verifies that un-archiving leaves the conversation open, unlike archiving which closes its tab.
+	/// </summary>
+	/// <remarks>
+	/// Archiving closes the tab because leaving an archived conversation open and re-activating it on the
+	/// next keystroke is a confusing pair of behaviours. Un-archiving has no such tension: the user has just
+	/// said they want this conversation back, so taking it off their screen would be perverse.
+	/// </remarks>
+	[Fact]
+	public async Task Un_archiving_leaves_the_conversation_open()
+	{
+		var (component, store) = await RenderFullScreenWithConversationAsync(isArchived: true);
+
+		await component.Find("button[title*='Un-archive']").ClickAsync(new());
+
+		component.Markup.Should().Contain(store.Conversation.DisplayName);
+	}
+
+	/// <summary>
+	/// Renders PDChat full-screen with one conversation open, in the given archive state.
+	/// </summary>
+	private async Task<(IRenderedComponent<PDChat> Component, RecordingConversationStore Store)>
+		RenderFullScreenWithConversationAsync(bool isArchived)
+	{
+		var chatService = new DumbChatService { DockMode = PDChatDockMode.FullScreen };
+		var store = new RecordingConversationStore(isArchived);
+
+		var component = Render<PDChat>(parameters => parameters
+			.Add(p => p.ChatService, chatService)
+			.Add(p => p.User, new ChatMessageSender { Name = "Tester", IsUser = true, IsHuman = true })
+			.Add(p => p.ConversationService, store));
+
+		// An archived conversation is not in the default list, so it is not auto-opened - which is the point
+		// of archiving. Reaching it is the journey a user actually takes: include archived conversations in
+		// the list, then open the one you want back. Doing that here means these tests exercise the only
+		// route to the control rather than a shortcut that does not exist in the product.
+		if (isArchived)
+		{
+			await component.Find(".pdchat-conversation-include-archived input").ChangeAsync(new() { Value = true });
+			await component.Find(".pdchat-conversation-row").ClickAsync(new());
+		}
+
+		return (component, store);
+	}
+
+	/// <summary>
+	/// A conversation store holding exactly one conversation, recording what was asked of it.
+	/// </summary>
+	private sealed class RecordingConversationStore : IChatConversationService
+	{
+		public RecordingConversationStore(bool isArchived)
+		{
+			ConversationId = ChatConversation.ImplicitConversationId;
+			Conversation = new ChatConversation
+			{
+				Id = ConversationId,
+				Title = "A conversation",
+				IsArchived = isArchived
+			};
+		}
+
+		public Guid ConversationId { get; }
+
+		public ChatConversation Conversation { get; }
+
+		public List<Guid> Unarchived { get; } = [];
+
+		public List<Guid> Archived { get; } = [];
+
+		public Task<ChatConversationPage> ListAsync(ChatConversationQuery query, CancellationToken cancellationToken)
+			=> Task.FromResult(new ChatConversationPage
+			{
+				Conversations = query.IncludeArchived || !Conversation.IsArchived ? [Conversation] : [],
+				TotalCount = 1
+			});
+
+		public Task<IReadOnlyList<ChatMessage>> GetMessagesAsync(Guid id, CancellationToken cancellationToken)
+			=> Task.FromResult<IReadOnlyList<ChatMessage>>([]);
+
+		public Task<ChatConversation> CreateAsync(CancellationToken cancellationToken)
+			=> Task.FromResult(new ChatConversation { Id = Guid.NewGuid() });
+
+		public Task RenameAsync(Guid id, string title, CancellationToken cancellationToken)
+			=> Task.CompletedTask;
+
+		public Task ArchiveAsync(Guid id, CancellationToken cancellationToken)
+		{
+			Archived.Add(id);
+			Conversation.IsArchived = true;
+			return Task.CompletedTask;
+		}
+
+		public Task UnarchiveAsync(Guid id, CancellationToken cancellationToken)
+		{
+			Unarchived.Add(id);
+			Conversation.IsArchived = false;
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/PanoramicData.Blazor/Models/ChatConversation.cs
+++ b/PanoramicData.Blazor/Models/ChatConversation.cs
@@ -76,9 +76,20 @@ public class ChatConversation
 	/// Gets or sets a value indicating whether the conversation has been archived.
 	/// </summary>
 	/// <remarks>
-	/// Archived means hidden from the default list, never removed and never unreadable. Interacting with an
-	/// archived conversation is expected to un-archive it, so that picking a conversation back up does not need
-	/// a second deliberate action.
+	/// <para>
+	/// Archived means hidden from the default list, never removed and never unreadable. An archived
+	/// conversation can be listed (<c>ChatConversationQuery.IncludeArchived</c>), opened, read and replied to;
+	/// archiving hides it, it does not close it off.
+	/// </para>
+	/// <para>
+	/// <b>Opening an archived conversation does not un-archive it.</b> An earlier version of this remark said
+	/// the opposite - that interacting with one should un-archive it, so picking a conversation back up needed
+	/// no second action. That cannot coexist with an un-archive control, which by definition acts on a
+	/// conversation that is open and still archived: auto-un-archiving on open means the control can never
+	/// appear. It also made the archived filter self-defeating, since merely looking at an archived
+	/// conversation would drag it back into the default list. Un-archiving is now an explicit act - see
+	/// <c>IChatConversationService.UnarchiveAsync</c>.
+	/// </para>
 	/// </remarks>
 	public bool IsArchived { get; set; }
 

--- a/PanoramicData.Blazor/PDChat.razor
+++ b/PanoramicData.Blazor/PDChat.razor
@@ -144,6 +144,19 @@
 										@onclick="ArchiveSelectedConversationAsync">
 									Archive
 								</button>
+
+								@* Hidden rather than disabled when the conversation is not archived: un-archiving
+								   something that was never archived is meaningless, not merely unavailable, and a
+								   permanently greyed control teaches the reader nothing about when it would apply. *@
+								@if (SelectedConversationIsArchived)
+								{
+									<button type="button"
+											class="pdchat-conversation-toolbar-btn"
+											title="Un-archive this conversation, returning it to the default list"
+											@onclick="UnarchiveSelectedConversationAsync">
+										Un-archive
+									</button>
+								}
 							</div>
 
 							@* One tab per OPEN conversation, using the library's own PDTabSet rather than a bespoke

--- a/PanoramicData.Blazor/PDChat.razor.cs
+++ b/PanoramicData.Blazor/PDChat.razor.cs
@@ -897,6 +897,57 @@ public partial class PDChat : JSModuleComponentBase
 	}
 
 	/// <summary>
+	/// Gets a value indicating whether the conversation currently shown is archived.
+	/// </summary>
+	/// <remarks>
+	/// Read from the open conversation rather than re-queried, so that the control appears and disappears in
+	/// step with the archive and un-archive actions without a round trip to the store.
+	/// </remarks>
+	private bool SelectedConversationIsArchived
+		=> _selectedConversationId is { } id
+			&& _openConversations.FirstOrDefault(conversation => conversation.Id == id)?.IsArchived == true;
+
+	/// <summary>
+	/// Returns the selected conversation to the default list.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The counterpart to <see cref="ArchiveSelectedConversationAsync"/>, and the reason archiving is not a
+	/// disguised delete: whatever archiving hid can be brought back.
+	/// </para>
+	/// <para>
+	/// Unlike archiving, this deliberately leaves the tab open. Archiving closes the tab because leaving an
+	/// archived conversation open and re-activating it on the next keystroke is a confusing pair of
+	/// behaviours; un-archiving has no such tension - the user has just said they want this conversation
+	/// back, so taking it off their screen would be perverse.
+	/// </para>
+	/// </remarks>
+	private async Task UnarchiveSelectedConversationAsync()
+	{
+		if (ConversationService is null || _selectedConversationId is not { } conversationId)
+		{
+			return;
+		}
+
+		await ConversationService.UnarchiveAsync(conversationId, CancellationToken.None);
+
+		// Update the open copy so the control disappears immediately, rather than waiting for the sidebar
+		// reload to come back and tell us what we already know.
+		var open = _openConversations.FirstOrDefault(conversation => conversation.Id == conversationId);
+		if (open is not null)
+		{
+			open.IsArchived = false;
+		}
+
+		if (_conversationSidebar is not null)
+		{
+			await _conversationSidebar.ReloadAsync();
+		}
+
+		await InvokeAsync(StateHasChanged);
+	}
+
+	/// <summary>
 	/// Archives the selected conversation and closes its tab.
 	/// </summary>
 	/// <remarks>


### PR DESCRIPTION
Closes #121. Jira: [MS-25789](https://jira.panoramicdata.com/browse/MS-25789) (un-archive slice).

`UnarchiveAsync` has existed since #108 and **nothing called it**. Archive was effectively one-way in the UI — and an archive with no way back is a delete wearing a different name, which is the one thing this feature promises never to do.

## A contradiction I had to resolve

- `ChatConversation.IsArchived` (from #102): *"Interacting with an archived conversation is expected to un-archive it."*
- MS-25789: un-archive control *"shown only when the current conversation is archived"*.

Mutually exclusive — if opening auto-un-archives, an open conversation is never archived and the control never appears.

**MS-25789 wins**, and not just for being newer: auto-un-archiving on open makes the archived filter self-defeating, since merely *looking* at an archived conversation drags it back into the default list. You could never browse your archive without destroying it. The `IsArchived` remark is corrected here, recording what it used to say and why, so nobody reintroduces it.

## Decisions

- **Hidden, not disabled**, when not archived — MS-25789's own stated exception to its "disable with a reason" rule.
- **Archiving closes the tab; un-archiving does not.** The user has just said they want the conversation back; removing it from their screen would be perverse.

## Verified in a browser — the whole journey

| Step | Result |
|---|---|
| Default list (archived hidden) | 3 conversations |
| Un-archive control shown initially | no |
| Tick *Include archived* | 4 conversations |
| Open the archived one | opens as its own tab |
| Still archived after opening | yes |
| Un-archive control now shown | yes |
| Use it → control disappears | yes |
| Tab stays open | yes |
| **Untick *Include archived* → conversation in the DEFAULT list** | **yes** |
| Console errors | none |

That last row is the one that matters: it proves the store changed, not just the component.

5 bUnit tests, red-checked by stubbing out the `UnarchiveAsync` call. 473 tests pass; Release build clean.

## Not in scope

The import/export controls MS-25789 also describes depend on MS-25790 (the JSON format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)