### PR TITLE
Fix #123: load NavigationCancelService's JS module lazily, not in the constructor

### DIFF
--- a/PanoramicData.Blazor/Services/NavigationCancelService.cs
+++ b/PanoramicData.Blazor/Services/NavigationCancelService.cs
@@ -6,7 +6,10 @@
 /// <param name="jsRuntime">The <see cref="IJSRuntime"/> used to invoke the browser confirmation dialog.</param>
 public class NavigationCancelService(IJSRuntime jsRuntime) : INavigationCancelService
 {
-    private readonly Task<IJSObjectReference>? _loadCommonJsTask = jsRuntime.InvokeAsync<IJSObjectReference>("import", JSInteropVersionHelper.CommonJsUrl).AsTask();
+    // Loaded lazily on first use: starting the import here (a constructor field initialiser) faults
+    // during Blazor Server prerendering, where JS interop is unavailable, and the unawaited task then
+    // surfaces as a TaskScheduler.UnobservedTaskException on every page load. See issue #123.
+    private Task<IJSObjectReference>? _loadCommonJsTask;
 
 	/// <summary>
 	/// Event raised before a navigation occurs.
@@ -31,8 +34,11 @@ public class NavigationCancelService(IJSRuntime jsRuntime) : INavigationCancelSe
         // ask listening code if operation should be canceled
         var args = new BeforeNavigateEventArgs { Target = target };
         BeforeNavigate?.Invoke(this, args);
-        if (args.Cancel && _loadCommonJsTask != null)
+        if (args.Cancel)
         {
+            // by the time a listener cancels a navigation the circuit is interactive, so JS interop is safe
+            _loadCommonJsTask ??= jsRuntime.InvokeAsync<IJSObjectReference>("import", JSInteropVersionHelper.CommonJsUrl).AsTask();
+
             // allow user option to override and perform operation regardless
             var commonModule = await _loadCommonJsTask.ConfigureAwait(true);
             if (commonModule != null)


### PR DESCRIPTION
Fixes #123.

`NavigationCancelService` started a JS interop import in its constructor field initialiser. The service is scoped and resolved during Blazor Server's static prerender pass, where JS interop throws — and since nothing awaits the stored task unless `ProceedAsync` later runs, the fault surfaced as a `TaskScheduler.UnobservedTaskException` logged at Error level on **every page load** of every consuming app, with a finalizer stack that identifies nothing (attributed in MagicSuite via a `FirstChanceException` stack capture — see MS-25810 / panoramicdata/MagicSuite#102).

The module is now imported on first use inside `ProceedAsync`: by the time a listener cancels a navigation the circuit is interactive, so the confirm-dialog behaviour is unchanged. `PanoramicData.Blazor` builds clean with the change.

MagicSuite currently carries a prerender-safe `INavigationCancelService` override registered after `AddPanoramicDataBlazor()`; that override will be removed once a version containing this fix is published and consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)